### PR TITLE
chore: Update slack testing channel naming

### DIFF
--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -127,7 +127,7 @@ slack:
   api:
     token: ${SLACK_API_TOKEN:}
   job:
-    notification-channel: slacktesting
+    notification-channel: testing-slack-integration
 
 kc:
   realm: ${KC_REALM:lin}


### PR DESCRIPTION
The slack channel for integration testing is to be renamed from
slacktesting to test-slack-integration, update the config to use the
new channel name.

TISNEW-5047