### PR TITLE
allow environment override of slack channel

### DIFF
--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -53,6 +53,6 @@ application:
 
 slack:
   job:
-    notification-channel: monitoring-prod
+    notification-channel: ${SLACK_NOTIFICATION_CHANNEL:monitoring-prod}
 
 enable.es.search: ${ENABLE_ES_SEARCH}


### PR DESCRIPTION
I wanted to allow use of a different channel without needing to rebuild the project.