### PR TITLE
chore: Upgrade Spring Boot to 2.3.4.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>tis-parent</artifactId>
-    <groupId>com.transformuk.hee</groupId>
-    <version>3.0.3</version>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.3.1.RELEASE</version>
     <relativePath />
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.7.3</version>
+  <version>1.8.0</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>
@@ -47,7 +47,12 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>1.7.1</version>
+      <version>2.13.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.transformuk.hee</groupId>
+      <artifactId>audit</artifactId>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>
@@ -171,6 +176,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.flywaydb</groupId>
+        <artifactId>flyway-core</artifactId>
+        <version>5.2.4</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <defaultGoal>spring-boot:run</defaultGoal>

--- a/src/main/java/uk/nhs/tis/sync/config/AuditingAspectConfiguration.java
+++ b/src/main/java/uk/nhs/tis/sync/config/AuditingAspectConfiguration.java
@@ -1,0 +1,17 @@
+package uk.nhs.tis.sync.config;
+
+import com.transformuk.hee.tis.audit.repository.TisAuditRepository;
+import org.springframework.boot.actuate.audit.AuditEventRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AuditingAspectConfiguration {
+
+  @Bean
+  public AuditEventRepository auditEventRepository() {
+    return new TisAuditRepository();
+  }
+}

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -12,10 +12,6 @@ spring:
   elasticsearch:
     rest:
       uris: ${ES_URLS}
-  data:
-    elasticsearch:
-      cluster-nodes: ${ES_CLUSTER_NODE_URLS}
-      cluster-name: ${ES_CLUSTER_NAME}
 
 logging:
   file: ${LOG_DIR:${HOME}}/sync.log

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -12,10 +12,6 @@ spring:
   elasticsearch:
     rest:
       uris: http://localhost:9200
-  data:
-    elasticsearch:
-      cluster-nodes: localhost:9300
-      cluster-name: docker-cluster
   jpa:
     show_sql: false
 

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -33,10 +33,6 @@ spring:
   elasticsearch:
     rest:
       uris: ${ES_URLS}
-  data:
-    elasticsearch:
-      cluster-nodes: ${ES_CLUSTER_NODE_URLS}
-      cluster-name: ${ES_CLUSTER_NAME}
 
 application:
 

--- a/src/main/resources/config/application-stage.yml
+++ b/src/main/resources/config/application-stage.yml
@@ -14,10 +14,6 @@ spring:
   elasticsearch:
     rest:
       uris: ${ES_URLS}
-  data:
-    elasticsearch:
-      cluster-nodes: ${ES_CLUSTER_NODE_URLS}
-      cluster-name: ${ES_CLUSTER_NAME}
 
 logging:
   file: ${LOG_DIR:${HOME}}/sync.log

--- a/src/main/resources/config/application-uidev.yml
+++ b/src/main/resources/config/application-uidev.yml
@@ -12,10 +12,6 @@ spring:
   elasticsearch:
     rest:
       uris: ${ES_URLS}
-  data:
-    elasticsearch:
-      cluster-nodes: ${ES_CLUSTER_NODE_URLS}
-      cluster-name: ${ES_CLUSTER_NAME}
 
 logging:
   file: ${LOG_DIR:${HOME}}/sync.log


### PR DESCRIPTION
Upgrade Spring Boot to the latest version, remove tis-parent as a parent
pom and use the spring boot starter parent instead.

TISNEW-4806