### PR TITLE
chore: Add sonar scanner plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,6 +313,10 @@
         <version>2.5</version>
       </plugin>
       <plugin>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.5</version>


### PR DESCRIPTION
The sonar scanner plugin was previously provided by tis-parent which has
been removed.

TISNEW-4806