### PR TITLE
fix: Reduce maximum page size for ES sync by 20%

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
@@ -213,7 +213,6 @@ public class PersonRecordStatusJob {
   protected String getSuccessMessage(Optional<String> jobName) {
     return "Sync [" + jobName.orElse(getJobName()) + "] completed successfully.";
   }
-  
 
   protected String getFailureMessage(Optional<String> jobName, Exception e) {
     return "<!channel> Sync [" + jobName.orElse(getJobName()) + "] failed with exception ["

--- a/src/main/java/uk/nhs/tis/sync/job/person/PersonElasticSearchSyncJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/person/PersonElasticSearchSyncJob.java
@@ -34,7 +34,7 @@ public class PersonElasticSearchSyncJob {
 
   private Stopwatch mainStopWatch;
 
-  protected static final int DEFAULT_PAGE_SIZE = 10_000;
+  protected static final int DEFAULT_PAGE_SIZE = 8_000;
 
   @Autowired
   private SqlQuerySupplier sqlQuerySupplier;


### PR DESCRIPTION
The AWS managed instances have a maximum request size of 10mb, which is
being exceeded. Reduce the default page size from 10k to 8k to reduce
the request sizes.

TISNEW-4806