### PR TITLE
fix: Reduce max lifetime on datasource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.8.1</version>
+  <version>1.8.2</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -62,6 +62,7 @@ spring:
         rewriteBatchedStatements: true
         useLocalSessionState: true
       maximumPoolSize: 20
+      maxLifetime: 380000
   jackson:
     serialization.write_dates_as_timestamps: false
     serialization.indent_output: true


### PR DESCRIPTION
The NIMDTA sync fails due to connection timeouts, reduce the max
lifetime to a value less than the database's configured wait timeout so
that a new connection is forced.

TISNEW-5812