### PR TITLE
refactor: Use Amazon defaultClient() for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ This Service takes the current cron jobs from the TCS service, running them from
 
 For more description, see [Confluence Sync Service Description](https://hee-tis.atlassian.net/wiki/spaces/NTCS/pages/1263271954/Sync+Service)
 
+## Pre-requisites
+The following environmental variables must be provided
+ - `AWS_ACCESS_KEY_ID`
+ - `AWS_SECRET_ACCESS_KEY`
+ - `AWS_REGION`
+
 ## Run jobs out of schedule
 
 ### Job Execution Order

--- a/src/main/java/uk/nhs/tis/sync/config/AmazonKinesisConfiguration.java
+++ b/src/main/java/uk/nhs/tis/sync/config/AmazonKinesisConfiguration.java
@@ -1,44 +1,18 @@
 package uk.nhs.tis.sync.config;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class AmazonKinesisConfiguration {
 
-  @Value("${application.aws.access.key.id}")
-  private String awsAccessKeyId;
-
-  @Value("${application.aws.secret.access.key}")
-  private String awsSecretAccessKey;
-
-  @Value("${application.aws.region}")
-  private String region;
-
-  AWSCredentialsProvider credentialsProvider() {
-    BasicAWSCredentials basic = new BasicAWSCredentials(this.awsAccessKeyId,
-        this.awsSecretAccessKey);
-    return new AWSStaticCredentialsProvider(basic);
-  }
-
   /**
-   *
    * @return an Amazon Kinesis object, necessary to send data into a Kinesis stream.
    */
   @Bean
   public AmazonKinesis amazonKinesis() {
-    AmazonKinesisClientBuilder clientBuilder =  AmazonKinesisClientBuilder.standard();
-    clientBuilder.setRegion(region);
-    clientBuilder.setCredentials(credentialsProvider());
-    clientBuilder.setClientConfiguration(new ClientConfiguration());
-    return clientBuilder.build();
+    return AmazonKinesisClientBuilder.defaultClient();
   }
-
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -206,13 +206,6 @@ application:
     personRecordStatusJob:
       dateOfChangeOverride: ${APPLICATION_JOBS_PERSONRECORDSTATUSJOB_DATEOFCHANGEOVERRIDE:}
   aws:
-    access:
-      key:
-        id: ${AWS_ACCESS_KEY_ID}
-    secret:
-      access:
-        key: ${AWS_SECRET_ACCESS_KEY}
-    region: ${AWS_REGION:eu-west-2}
     kinesis:
       streamName: ${AWS_KINESIS_STREAM_NAME}
     sqs:

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -101,13 +101,6 @@ application:
     personRecordStatusJob:
       dateOfChangeOverride: ${APPLICATION_JOBS_PERSONRECORDSTATUSJOB_DATEOFCHANGEOVERRIDE:}
   aws:
-    access:
-      key:
-        id: accessKeyId
-    secret:
-      access:
-        key: secretAccessKey
-    region: eu-west-2
     kinesis:
       streamName: ${AWS_KINESIS_STREAM_NAME:streamName}
     sqs:


### PR DESCRIPTION
The Amazon default client can get credentials automatically, when
running in AWS these credentials can then be passed from the role
associated with the ECS task or EC2 instance.
This technique removes the burden of managing credentials, AWS will
automatically provide and rotate credentials for us.

TIS21-1032