### PR TITLE
fix: Delete messages after processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.10.0</version>
+  <version>1.10.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/job/RecordResendingJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/RecordResendingJob.java
@@ -1,13 +1,16 @@
 package uk.nhs.tis.sync.job;
 
 import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequest;
+import com.amazonaws.services.sqs.model.DeleteMessageBatchRequestEntry;
 import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.concurrent.CompletableFuture;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,21 +48,22 @@ public class RecordResendingJob {
   private String streamName;
 
   /**
-   * A job that reads queue messages, interprets what dto is being requested, fetches it, and
-   * sends it as data into a kinesis stream.
-   * @param kinesisService A service responsible for outputting into the stream.
-   * @param dataRequestService         A service wrapping TcsServiceImpl to fetch a dto.
-   * @param objectMapper               To map a message into an AmazonSqsMessageDto.
-   * @param sqs                        An AmazonSQS object to interact with a queue.
-   * @param queueUrl                   The url of the queue to interact with.
+   * A job that reads queue messages, interprets what dto is being requested, fetches it, and sends
+   * it as data into a kinesis stream.
+   *
+   * @param kinesisService     A service responsible for outputting into the stream.
+   * @param dataRequestService A service wrapping TcsServiceImpl to fetch a dto.
+   * @param objectMapper       To map a message into an AmazonSqsMessageDto.
+   * @param sqs                An AmazonSQS object to interact with a queue.
+   * @param queueUrl           The url of the queue to interact with.
    */
   public RecordResendingJob(KinesisService kinesisService,
-                            DataRequestService dataRequestService,
-                            ObjectMapper objectMapper,
-                            AmazonSQS sqs,
-                            @Value("${application.aws.sqs.queueUrl}") String queueUrl,
-                            DmsRecordAssembler dmsRecordAssembler,
-                            @Value("${application.aws.kinesis.streamName}") String streamName) {
+      DataRequestService dataRequestService,
+      ObjectMapper objectMapper,
+      AmazonSQS sqs,
+      @Value("${application.aws.sqs.queueUrl}") String queueUrl,
+      DmsRecordAssembler dmsRecordAssembler,
+      @Value("${application.aws.kinesis.streamName}") String streamName) {
     this.kinesisService = kinesisService;
     this.dataRequestService = dataRequestService;
     this.objectMapper = objectMapper;
@@ -83,26 +87,58 @@ public class RecordResendingJob {
     try {
       LOG.info("Reading [{}] started", JOB_NAME);
       List<DmsDto> dmsDtoList = new ArrayList<>();
+      List<String> receiptHandles = new ArrayList<>();
 
-      List<Message> messages = sqs.receiveMessage(queueUrl).getMessages();
+      ReceiveMessageRequest request = new ReceiveMessageRequest()
+          .withQueueUrl(queueUrl)
+          .withMaxNumberOfMessages(10);
+      List<Message> messages = sqs.receiveMessage(request).getMessages();
+
       for (Message message : messages) {
-        String messageBody = message.getBody();
-        AmazonSqsMessageDto messageDto = objectMapper
-            .readValue(messageBody, AmazonSqsMessageDto.class);
-        LOG.info(messageBody);
+        DmsDto dmsDto = processMessage(message);
 
-        Object retrievedDto = dataRequestService.retrieveDto(messageDto);
-
-        if (retrievedDto != null) {
-          DmsDto dmsDto = dmsRecordAssembler.assembleDmsDto(retrievedDto);
+        if (dmsDto != null) {
           dmsDtoList.add(dmsDto);
+          receiptHandles.add(message.getReceiptHandle());
         }
       }
+
       if (!dmsDtoList.isEmpty()) {
         kinesisService.sendData(streamName, dmsDtoList);
+        deleteMessagesFromQueue(receiptHandles);
       }
     } catch (Exception e) {
       LOG.error(e.getMessage(), e);
     }
+  }
+
+  private DmsDto processMessage(Message message) {
+    try {
+      String messageBody = message.getBody();
+      AmazonSqsMessageDto messageDto = objectMapper
+          .readValue(messageBody, AmazonSqsMessageDto.class);
+      LOG.info(messageBody);
+
+      Object retrievedDto = dataRequestService.retrieveDto(messageDto);
+
+      if (retrievedDto != null) {
+        return dmsRecordAssembler.assembleDmsDto(retrievedDto);
+      }
+    } catch (JsonProcessingException e) {
+      LOG.error(e.getMessage(), e);
+    }
+
+    return null;
+  }
+
+  private void deleteMessagesFromQueue(List<String> receiptHandles) {
+    List<DeleteMessageBatchRequestEntry> requestEntries = new ArrayList<>();
+
+    for (ListIterator<String> iterator = receiptHandles.listIterator(); iterator.hasNext(); ) {
+      String index = String.valueOf(iterator.nextIndex());
+      String receiptHandle = iterator.next();
+      requestEntries.add(new DeleteMessageBatchRequestEntry(index, receiptHandle));
+    }
+    sqs.deleteMessageBatch(new DeleteMessageBatchRequest(queueUrl, requestEntries));
   }
 }


### PR DESCRIPTION
The messages that are processed and sent to the kinesis stream are not
removed from the SQS queue, delete messages that have been successfully
processed.

The current implementation takes a single message at a time, get the
maximum of ten instead.

TIS21-1032