### PR TITLE
chore: remove repackaging block from pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,17 +338,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>repackage</id>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-            <configuration>
-              <finalName>app</finalName>
-            </configuration>
-          </execution>
-        </executions>
         <configuration>
           <image>
             <name>${IMAGE_REGISTRY_URL}/sync</name>


### PR DESCRIPTION
Reverting back from the latest addition to the pom file. Doesn't need any renaming for the jar.