### PR TITLE
chore: Remove real AWS resources from config

### DIFF
--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -39,9 +39,9 @@ enable.es.search: false
 
 application:
   cron:
-    recordResendingJob: ${APPLICATION_CRON_RECORDRESENDINGJOB:0/10 * * * * *}
+    recordResendingJob: ${APPLICATION_CRON_RECORDRESENDINGJOB:-}
   aws:
     kinesis:
-      streamName: ${AWS_KINESIS_STREAM_NAME:azure-stage-db-to-aws-kinesis-continuous}
+      streamName: ${AWS_KINESIS_STREAM_NAME:}
     sqs:
-      queueUrl: ${AWS_SQS_QUEUE_URL:https://sqs.eu-west-2.amazonaws.com/430723991443/tis-trainee-sync-queue-preprod}
+      queueUrl: ${AWS_SQS_QUEUE_URL:}


### PR DESCRIPTION
The default local application config uses the preprod infrastructure for
trainee data requests.
These should be removed from the default config.

Disable the data request cron job.

TIS21-1642