### PR TITLE
chore: Allow ES url to be overridden locally

### DIFF
--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -11,7 +11,7 @@ spring:
     schemas: ${DBNAME:tcs}
   elasticsearch:
     rest:
-      uris: http://localhost:9200
+      uris: ${ES_URLS:http://localhost:9200}
   jpa:
     show_sql: false
 


### PR DESCRIPTION
The local profile uses a hardcoded URL referring to localhost, this does
not work correctly when running in Docker.
Add the `ES_URLS` environmental variable override, leave localhost
default.

NO-TICKET