### PR TITLE
chore(deps): bump tis-parent-client from 4.2.1 to 5.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.13.0</version>
+  <version>1.13.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>tis-security-jwt</artifactId>
-      <version>5.0.0</version>
+      <version>5.1.4</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Bump the version of `tis-parent-client` to `5.1.4` to update transient
dependency `tis-security-jwt` to `5.1.4`, which allows usage with
Cognito/AWS API Gateway.

TIS21-2477, TIS21-2474