### PR TITLE
Revert "chore(deps): bump shedlock-provider-jdbc-template from 2.5.0 to 4.31.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <dependency>
       <groupId>net.javacrumbs.shedlock</groupId>
       <artifactId>shedlock-provider-jdbc-template</artifactId>
-      <version>4.31.0</version>
+      <version>2.5.0</version>
     </dependency>
     <!-- Dependecies to try removing -->
     <dependency>


### PR DESCRIPTION
Reverts Health-Education-England/TIS-SYNC#146