### PR TITLE
Revert "chore(deps): bump checkstyle from 9.0.1 to 10.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>10.0</version>
+            <version>9.0.1</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
Reverts Health-Education-England/TIS-SYNC#155

I think we need to move from Java 1.8 to Java 11 for this.