### PR TITLE
chore: fix dockerization

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -140,7 +140,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: sync
         run: |
-          mvn spring-boot:build-image -DskipTests
+          mvn spring-boot:build-image -DskipTests -Dspring-boot.build-image.imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 

--- a/pom.xml
+++ b/pom.xml
@@ -329,9 +329,6 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
-          <image>
-            <name>${IMAGE_REGISTRY_URL}/sync</name>
-          </image>
           <executable>true</executable>
           <fork>true</fork>
           <!-- Enable the line below to have remote debugging of your application


### PR DESCRIPTION
Move the image name declaration to the workflow instead of the POM.

TIS21-2842
TIS21-2844