### PR TITLE
chore: fix task role

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -185,7 +185,7 @@
     "FARGATE"
   ],
   "executionRoleArn": "ecsTaskExecutionRole",
-  "taskRoleArn": "tis-trainee-sync_task-role_${environment}",
+  "taskRoleArn": "tis-sync_task-role_${environment}",
   "networkMode": "awsvpc",
   "cpu": "1024",
   "memory": "3072"


### PR DESCRIPTION
The deployed task is incorrectly using the `tis-trainee-sync` role
instead of its own `tis-sync` role.
The new roles have been created but need to be used during deployment.

TIS21-2842
TIS21-2844