### PR TITLE
chore: migrate from adopt to temurin in workflows

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           cache: maven
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Configure AWS credentials
@@ -100,7 +100,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           cache: maven
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Configure AWS credentials


### PR DESCRIPTION
The AdoptOpenJDK project has moved and rebranded to Adoptium, with
Temurin being the naming of the JDK binaries produced by the Adoptium
project.

TIS21-SHED