### PR TITLE
feat: add ProgrammeMembership DMS DTO mapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.15.0</version>
+  <version>1.16.0</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/pom.xml
+++ b/pom.xml
@@ -47,12 +47,12 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.21.0</version>
+      <version>2.23.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-client</artifactId>
-      <version>5.13.8</version>
+      <version>5.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
@@ -1,0 +1,31 @@
+package uk.nhs.tis.sync.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProgrammeMembershipDmsDto {
+  //CurriculumMembership details
+  private String id;
+  private String curriculumStartDate;
+  private String curriculumEndDate;
+  private String curriculumCompletionDate;
+  private String periodOfGrace;
+  private String curriculumId;
+  private String intrepidId;
+  private String programmeMembershipUuid;
+
+  //ProgrammeMembership details
+  private String personId;
+  private String programmeId;
+  private String rotationId;
+  private String rotation;
+  private String trainingNumberId;
+  private String trainingPathway;
+  private String programmeMembershipType;
+  private String programmeStartDate;
+  private String programmeEndDate;
+  private String leavingReason;
+  private String leavingDestination;
+}

--- a/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
@@ -1,0 +1,17 @@
+package uk.nhs.tis.sync.mapper;
+
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
+import org.mapstruct.Mapper;
+import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
+
+@Mapper(componentModel = "spring")
+public interface CurriculumMembershipMapper {
+
+  /**
+   * Converts a CurriculumMembershipDTO to a ProgrammeMembershipDmsDto.
+   *
+   * @param curriculumMembershipDto  the CurriculumMembershipDTO to convert
+   * @return                        the ProgrammeMembershipDmsDto
+   */
+  ProgrammeMembershipDmsDto toDmsDto(CurriculumMembershipDTO curriculumMembershipDto);
+}

--- a/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
@@ -10,8 +10,8 @@ public interface CurriculumMembershipMapper {
   /**
    * Converts a CurriculumMembershipDTO to a ProgrammeMembershipDmsDto.
    *
-   * @param curriculumMembershipDto  the CurriculumMembershipDTO to convert
-   * @return                        the ProgrammeMembershipDmsDto
+   * @param curriculumMembershipDto   the CurriculumMembershipDTO to convert
+   * @return                          the ProgrammeMembershipDmsDto
    */
   ProgrammeMembershipDmsDto toDmsDto(CurriculumMembershipDTO curriculumMembershipDto);
 }

--- a/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
@@ -3,15 +3,14 @@ package uk.nhs.tis.sync.mapper;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
+import java.util.UUID;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
-import java.util.UUID;
 
 @Mapper(componentModel = "spring",
         uses = {CurriculumMembershipMapper.class})
@@ -20,29 +19,28 @@ public interface ProgrammeMembershipMapper {
   /**
    * Converts a ProgrammeMembershipDTO to a ProgrammeMembershipDmsDto.
    *
-   * Note that the ProgrammeMembershipDTO should have exactly one child CurriculumMembershipDTO,
+   * <p>Note that the ProgrammeMembershipDTO should have exactly one child CurriculumMembershipDTO,
    * i.e. it should be a non-normalised ProgrammeMembershipDTO, not one which has been normalised by
-   * ProgrammeMembershipServiceImpl.findProgrammeMembershipsForTraineeRolledUp()
+   * ProgrammeMembershipServiceImpl.findProgrammeMembershipsForTraineeRolledUp()</p>
    *
    * @param programmeMembershipDto  the ProgrammeMembershipDTO to convert
    * @return                        the ProgrammeMembershipDmsDto
    */
-  @Mappings({
-      @Mapping(target="rotation", source="rotation.name"),
-      @Mapping(target="rotationId", source="rotation.id"),
-      @Mapping(target="programmeMembershipUuid", source="uuid",
-          qualifiedByName="getProgrammeMembershipUuid"),
-      @Mapping(target="personId", source="person.id"),
-      @Mapping(target="trainingNumberId", source="trainingNumber.id"),
-      @Mapping(target="programmeMembershipType", source="programmeMembershipType",
-          qualifiedByName="getProgrammeMembershipType"),
-      @Mapping(target="curriculumStartDate", ignore=true),
-      @Mapping(target="curriculumEndDate", ignore=true),
-      @Mapping(target="curriculumCompletionDate", ignore=true),
-      @Mapping(target="periodOfGrace", ignore=true),
-      @Mapping(target="curriculumId", ignore=true),
-      @Mapping(target="intrepidId", ignore=true)
-  })
+
+  @Mapping(target = "rotation", source = "rotation.name")
+  @Mapping(target = "rotationId", source = "rotation.id")
+  @Mapping(target = "programmeMembershipUuid", source = "uuid",
+      qualifiedByName = "getProgrammeMembershipUuid")
+  @Mapping(target = "personId", source = "person.id")
+  @Mapping(target = "trainingNumberId", source = "trainingNumber.id")
+  @Mapping(target = "programmeMembershipType", source = "programmeMembershipType",
+      qualifiedByName = "getProgrammeMembershipType")
+  @Mapping(target = "curriculumStartDate", ignore = true)
+  @Mapping(target = "curriculumEndDate", ignore = true)
+  @Mapping(target = "curriculumCompletionDate", ignore = true)
+  @Mapping(target = "periodOfGrace", ignore = true)
+  @Mapping(target = "curriculumId", ignore = true)
+  @Mapping(target = "intrepidId", ignore = true)
   ProgrammeMembershipDmsDto toDmsDto(ProgrammeMembershipDTO programmeMembershipDto);
 
   @Named("getProgrammeMembershipUuid")
@@ -65,10 +63,13 @@ public interface ProgrammeMembershipMapper {
   default void setCurriculumDetails(ProgrammeMembershipDTO programmeMembershipDto,
                                     @MappingTarget ProgrammeMembershipDmsDto dmsDto) {
     if (programmeMembershipDto.getCurriculumMemberships() != null) {
-      CurriculumMembershipDTO curriculumMembershipDto = programmeMembershipDto.getCurriculumMemberships().get(0);
+      CurriculumMembershipDTO curriculumMembershipDto
+          = programmeMembershipDto.getCurriculumMemberships().get(0);
 
-      CurriculumMembershipMapper curriculumMembershipMapper = Mappers.getMapper(CurriculumMembershipMapper.class);
-      ProgrammeMembershipDmsDto dmsDtoCurriculumDetails = curriculumMembershipMapper.toDmsDto(curriculumMembershipDto);
+      CurriculumMembershipMapper curriculumMembershipMapper
+          = Mappers.getMapper(CurriculumMembershipMapper.class);
+      ProgrammeMembershipDmsDto dmsDtoCurriculumDetails
+          = curriculumMembershipMapper.toDmsDto(curriculumMembershipDto);
       dmsDto.setCurriculumStartDate(dmsDtoCurriculumDetails.getCurriculumStartDate());
       dmsDto.setCurriculumEndDate(dmsDtoCurriculumDetails.getCurriculumEndDate());
       dmsDto.setCurriculumCompletionDate(dmsDtoCurriculumDetails.getCurriculumCompletionDate());

--- a/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
@@ -11,9 +11,6 @@ import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
-
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.UUID;
 
 @Mapper(componentModel = "spring",

--- a/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
@@ -1,0 +1,83 @@
+package uk.nhs.tis.sync.mapper;
+
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.UUID;
+
+@Mapper(componentModel = "spring",
+        uses = {CurriculumMembershipMapper.class})
+public interface ProgrammeMembershipMapper {
+
+  /**
+   * Converts a ProgrammeMembershipDTO to a ProgrammeMembershipDmsDto.
+   *
+   * Note that the ProgrammeMembershipDTO should have exactly one child CurriculumMembershipDTO,
+   * i.e. it should be a non-normalised ProgrammeMembershipDTO, not one which has been normalised by
+   * ProgrammeMembershipServiceImpl.findProgrammeMembershipsForTraineeRolledUp()
+   *
+   * @param programmeMembershipDto  the ProgrammeMembershipDTO to convert
+   * @return                        the ProgrammeMembershipDmsDto
+   */
+  @Mappings({
+      @Mapping(target="rotation", source="rotation.name"),
+      @Mapping(target="rotationId", source="rotation.id"),
+      @Mapping(target="programmeMembershipUuid", source="uuid",
+          qualifiedByName="getProgrammeMembershipUuid"),
+      @Mapping(target="personId", source="person.id"),
+      @Mapping(target="trainingNumberId", source="trainingNumber.id"),
+      @Mapping(target="programmeMembershipType", source="programmeMembershipType",
+          qualifiedByName="getProgrammeMembershipType"),
+      @Mapping(target="curriculumStartDate", ignore=true),
+      @Mapping(target="curriculumEndDate", ignore=true),
+      @Mapping(target="curriculumCompletionDate", ignore=true),
+      @Mapping(target="periodOfGrace", ignore=true),
+      @Mapping(target="curriculumId", ignore=true),
+      @Mapping(target="intrepidId", ignore=true)
+  })
+  ProgrammeMembershipDmsDto toDmsDto(ProgrammeMembershipDTO programmeMembershipDto);
+
+  @Named("getProgrammeMembershipUuid")
+  default String getProgrammeMembershipUuid(UUID uuid) {
+    if (uuid != null) {
+      return uuid.toString();
+    }
+    return null;
+  }
+
+  @Named("getProgrammeMembershipType")
+  default String getProgrammeMembershipType(ProgrammeMembershipType programmeMembershipType) {
+    if (programmeMembershipType != null) {
+      return programmeMembershipType.toString();
+    }
+    return null;
+  }
+
+  @AfterMapping
+  default void setCurriculumDetails(ProgrammeMembershipDTO programmeMembershipDto,
+                                    @MappingTarget ProgrammeMembershipDmsDto dmsDto) {
+    if (programmeMembershipDto.getCurriculumMemberships() != null) {
+      CurriculumMembershipDTO curriculumMembershipDto = programmeMembershipDto.getCurriculumMemberships().get(0);
+
+      CurriculumMembershipMapper curriculumMembershipMapper = Mappers.getMapper(CurriculumMembershipMapper.class);
+      ProgrammeMembershipDmsDto dmsDtoCurriculumDetails = curriculumMembershipMapper.toDmsDto(curriculumMembershipDto);
+      dmsDto.setCurriculumStartDate(dmsDtoCurriculumDetails.getCurriculumStartDate());
+      dmsDto.setCurriculumEndDate(dmsDtoCurriculumDetails.getCurriculumEndDate());
+      dmsDto.setCurriculumCompletionDate(dmsDtoCurriculumDetails.getCurriculumCompletionDate());
+      dmsDto.setPeriodOfGrace(dmsDtoCurriculumDetails.getPeriodOfGrace());
+      dmsDto.setCurriculumId(dmsDtoCurriculumDetails.getCurriculumId());
+      dmsDto.setIntrepidId(dmsDtoCurriculumDetails.getIntrepidId());
+    }
+  }
+}

--- a/src/main/java/uk/nhs/tis/sync/service/DmsRecordAssembler.java
+++ b/src/main/java/uk/nhs/tis/sync/service/DmsRecordAssembler.java
@@ -28,6 +28,7 @@ import uk.nhs.tis.sync.mapper.PlacementDetailsMapper;
 import uk.nhs.tis.sync.mapper.PlacementSpecialtyMapper;
 import uk.nhs.tis.sync.mapper.PostMapper;
 import uk.nhs.tis.sync.mapper.ProgrammeMapper;
+import uk.nhs.tis.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.tis.sync.mapper.SiteMapper;
 import uk.nhs.tis.sync.mapper.SpecialtyMapper;
 import uk.nhs.tis.sync.mapper.TrustMapper;
@@ -53,7 +54,7 @@ public class DmsRecordAssembler {
   private static final String TABLE_PLACEMENT_SPECIALTY = "PlacementSpecialty";
   private static final String TABLE_POST = "Post";
   private static final String TABLE_PROGRAMME = "Programme";
-  private static final String TABLE_PROGRAMME_MEMBERSHIP = "ProgrammeMembership";
+  private static final String TABLE_PROGRAMME_MEMBERSHIP = "CurriculumMembership";
   private static final String TABLE_QUALIFICATION = "Qualification";
   private static final String TABLE_SITE = "Site";
   private static final String TABLE_SPECIALTY = "Specialty";
@@ -75,15 +76,18 @@ public class DmsRecordAssembler {
 
   private final PlacementDetailsMapper placementDetailsMapper;
 
+  private final ProgrammeMembershipMapper programmeMembershipMapper;
+
   /**
    * Constructor for a DmsRecordAssembler, which instantiates the relevant mappers.
    */
   DmsRecordAssembler(PostMapper postMapper,
-      TrustMapper trustMapper, SiteMapper siteMapper,
-      ProgrammeMapper programmeMapper, CurriculumMapper curriculumMapper,
-      SpecialtyMapper specialtyMapper,
-      PlacementSpecialtyMapper placementSpecialtyMapper,
-      PlacementDetailsMapper placementDetailsMapper) {
+                     TrustMapper trustMapper, SiteMapper siteMapper,
+                     ProgrammeMapper programmeMapper, CurriculumMapper curriculumMapper,
+                     SpecialtyMapper specialtyMapper,
+                     PlacementSpecialtyMapper placementSpecialtyMapper,
+                     PlacementDetailsMapper placementDetailsMapper,
+                     ProgrammeMembershipMapper programmeMembershipMapper) {
     this.postMapper = postMapper;
     this.trustMapper = trustMapper;
     this.siteMapper = siteMapper;
@@ -92,6 +96,7 @@ public class DmsRecordAssembler {
     this.specialtyMapper = specialtyMapper;
     this.placementSpecialtyMapper = placementSpecialtyMapper;
     this.placementDetailsMapper = placementDetailsMapper;
+    this.programmeMembershipMapper = programmeMembershipMapper;
   }
 
   /**
@@ -180,7 +185,7 @@ public class DmsRecordAssembler {
     }
 
     if (dto instanceof ProgrammeMembershipDTO) {
-      // dmsData = programmeMembershipMapper.toDmsDto((ProgrammeMembershipDTO) dto);
+      dmsData = programmeMembershipMapper.toDmsDto((ProgrammeMembershipDTO) dto);
       schema = SCHEMA_TCS;
       table = TABLE_PROGRAMME_MEMBERSHIP;
     }

--- a/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
@@ -13,25 +13,33 @@ import com.transformuk.hee.tis.reference.api.dto.SiteDTO;
 import com.transformuk.hee.tis.reference.api.dto.TrustDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ContactDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.CurriculumDTO;
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.GdcDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.GmcDetailsDTO;
+import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PersonalDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementSpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PostDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeDTO;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
+import com.transformuk.hee.tis.tcs.api.dto.RotationDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import com.transformuk.hee.tis.tcs.api.dto.SpecialtyGroupDTO;
+import com.transformuk.hee.tis.tcs.api.dto.TrainingNumberDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.AssessmentType;
 import com.transformuk.hee.tis.tcs.api.enumeration.CurriculumSubType;
 import com.transformuk.hee.tis.tcs.api.enumeration.LifecycleState;
 import com.transformuk.hee.tis.tcs.api.enumeration.PlacementStatus;
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSpecialtyType;
+import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
 import com.transformuk.hee.tis.tcs.api.enumeration.Status;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -43,6 +51,7 @@ import uk.nhs.tis.sync.dto.PlacementDetailsDmsDto;
 import uk.nhs.tis.sync.dto.PlacementSpecialtyDmsDto;
 import uk.nhs.tis.sync.dto.PostDmsDto;
 import uk.nhs.tis.sync.dto.ProgrammeDmsDto;
+import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
 import uk.nhs.tis.sync.dto.SiteDmsDto;
 import uk.nhs.tis.sync.dto.SpecialtyDmsDto;
 import uk.nhs.tis.sync.dto.TrustDmsDto;
@@ -55,11 +64,13 @@ import uk.nhs.tis.sync.mapper.PlacementSpecialtyMapperImpl;
 import uk.nhs.tis.sync.mapper.PostMapperImpl;
 import uk.nhs.tis.sync.mapper.ProgrammeMapper;
 import uk.nhs.tis.sync.mapper.ProgrammeMapperImpl;
+import uk.nhs.tis.sync.mapper.ProgrammeMembershipMapper;
 import uk.nhs.tis.sync.mapper.SiteMapper;
 import uk.nhs.tis.sync.mapper.SiteMapperImpl;
 import uk.nhs.tis.sync.mapper.SpecialtyMapper;
 import uk.nhs.tis.sync.mapper.SpecialtyMapperImpl;
 import uk.nhs.tis.sync.mapper.TrustMapperImpl;
+import uk.nhs.tis.sync.mapper.ProgrammeMembershipMapperImpl;
 
 class DmsRecordAssemblerTest {
 
@@ -75,10 +86,11 @@ class DmsRecordAssemblerTest {
     SpecialtyMapper specialtyMapper = new SpecialtyMapperImpl();
     PlacementSpecialtyMapper placementSpecialtyMapper = new PlacementSpecialtyMapperImpl();
     PlacementDetailsMapper placementDetailsMapper = new PlacementDetailsMapperImpl();
+    ProgrammeMembershipMapper programmeMembershipMapper = new ProgrammeMembershipMapperImpl();
 
     dmsRecordAssembler = new DmsRecordAssembler(postMapper, trustMapper, siteMapper,
         programmeMapper, curriculumMapper, specialtyMapper, placementSpecialtyMapper,
-        placementDetailsMapper);
+        placementDetailsMapper, programmeMembershipMapper);
   }
 
   @Test
@@ -252,9 +264,87 @@ class DmsRecordAssemblerTest {
   }
 
   @Test
-  @Disabled("Not yet implemented")
-  void shouldAssembleProgrammeMembership() {
-    Assertions.fail("Not yet implemented.");
+  void shouldAssembleADmsDtoWhenGivenAProgrammeMembershipDto() {
+    PersonDTO personDto = new PersonDTO();
+    personDto.setId(1L);
+
+    RotationDTO rotationDto = new RotationDTO();
+    rotationDto.setId(2L);
+    rotationDto.setName("a rotation");
+
+    TrainingNumberDTO trainingNumberDto = new TrainingNumberDTO();
+    trainingNumberDto.setId(3L);
+
+    CurriculumMembershipDTO curriculumMembershipDto = new CurriculumMembershipDTO();
+    curriculumMembershipDto.setCurriculumId(4L);
+    curriculumMembershipDto.setId(1111L);
+    curriculumMembershipDto.setCurriculumStartDate(LocalDate.of(2021, 2, 2));
+    curriculumMembershipDto.setCurriculumEndDate(LocalDate.of(2022, 1, 1));
+    curriculumMembershipDto.setCurriculumCompletionDate(LocalDate.of(2022, 1, 2));
+    curriculumMembershipDto.setPeriodOfGrace(5);
+    curriculumMembershipDto.setIntrepidId("12345");
+
+    ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
+    programmeMembershipDto.setId(1111L);
+    programmeMembershipDto.setUuid(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    programmeMembershipDto.setPerson(personDto);
+    programmeMembershipDto.setProgrammeId(123L);
+    programmeMembershipDto.setRotation(rotationDto);
+    programmeMembershipDto.setTrainingNumber(trainingNumberDto);
+    programmeMembershipDto.setTrainingPathway("a training pathway");
+    programmeMembershipDto.setProgrammeMembershipType(ProgrammeMembershipType.SUBSTANTIVE);
+    programmeMembershipDto.setProgrammeStartDate(LocalDate.of(2021, 1, 1));
+    programmeMembershipDto.setProgrammeEndDate(LocalDate.of(2022, 2, 2));
+    programmeMembershipDto.setLeavingReason("a leaving reason");
+    programmeMembershipDto.setLeavingDestination("a leaving destination");
+    programmeMembershipDto.setCurriculumMemberships(Collections.singletonList(curriculumMembershipDto));
+
+    //when
+    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(programmeMembershipDto));
+
+    //then
+    assertThat("Unexpected DTO count.", actualDmsDtos.size(), is(1));
+    DmsDto actualDmsDto = actualDmsDtos.get(0);
+
+    ProgrammeMembershipDmsDto expectedProgrammeMembershipDmsDto = new ProgrammeMembershipDmsDto();
+    expectedProgrammeMembershipDmsDto.setId("1111");
+    expectedProgrammeMembershipDmsDto.setCurriculumStartDate("2021-02-02");
+    expectedProgrammeMembershipDmsDto.setCurriculumEndDate("2022-01-01");
+    expectedProgrammeMembershipDmsDto.setCurriculumCompletionDate("2022-01-02");
+    expectedProgrammeMembershipDmsDto.setPeriodOfGrace("5");
+    expectedProgrammeMembershipDmsDto.setCurriculumId("4");
+    expectedProgrammeMembershipDmsDto.setIntrepidId("12345");
+    expectedProgrammeMembershipDmsDto.setProgrammeMembershipUuid("123e4567-e89b-12d3-a456-426614174000");
+    expectedProgrammeMembershipDmsDto.setPersonId("1");
+    expectedProgrammeMembershipDmsDto.setProgrammeId("123");
+    expectedProgrammeMembershipDmsDto.setRotationId("2");
+    expectedProgrammeMembershipDmsDto.setRotation("a rotation");
+    expectedProgrammeMembershipDmsDto.setTrainingNumberId("3");
+    expectedProgrammeMembershipDmsDto.setTrainingPathway("a training pathway");
+    expectedProgrammeMembershipDmsDto.setProgrammeMembershipType(ProgrammeMembershipType.SUBSTANTIVE.toString());
+    expectedProgrammeMembershipDmsDto.setProgrammeStartDate("2021-01-01");
+    expectedProgrammeMembershipDmsDto.setProgrammeEndDate("2022-02-02");
+    expectedProgrammeMembershipDmsDto.setLeavingReason("a leaving reason");
+    expectedProgrammeMembershipDmsDto.setLeavingDestination("a leaving destination");
+
+    //inject the timestamp from the actualDmsDto into the expectedDmsDto
+    String timestamp = actualDmsDto.getMetadata().getTimestamp();
+
+    //inject the transaction-id from the actualDmsDto into the expectedDmsDto
+    String transactionId = actualDmsDto.getMetadata().getTransactionId();
+
+    MetadataDto expectedMetadataDto = new MetadataDto();
+    expectedMetadataDto.setTimestamp(timestamp);
+    expectedMetadataDto.setRecordType("data");
+    expectedMetadataDto.setOperation("load");
+    expectedMetadataDto.setPartitionKeyType("schema-table");
+    expectedMetadataDto.setSchemaName("tcs");
+    expectedMetadataDto.setTableName("CurriculumMembership");
+    expectedMetadataDto.setTransactionId(transactionId);
+
+    DmsDto expectedDmsDto = new DmsDto(expectedProgrammeMembershipDmsDto, expectedMetadataDto);
+
+    assertEquals(expectedDmsDto, actualDmsDto);
   }
 
   @Test


### PR DESCRIPTION
There may be a more elegant way of doing this. 

Also: until the Programme Membership refactoring in TCS is complete, we are caught with some awkward naming weirdness between programme / curriculum memberships (e.g. ProgrammeMembership comes from CurriculumMembership table 😱 )

TIS21-3076: Handle Programme Memberships