### PR TITLE
fix: PersonElasticSearch SQL for PM refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.16.0</version>
+  <version>1.16.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/service/PersonElasticSearchService.java
+++ b/src/main/java/uk/nhs/tis/sync/service/PersonElasticSearchService.java
@@ -225,7 +225,7 @@ public class PersonElasticSearchService {
   public void updatePersonDocumentForProgramme(Long programmeId) {
     String programmeMembershipQuery = sqlQuerySupplier
         .getQuery(SqlQuerySupplier.PROGRAMME_MEMBERSHIP_VIEW)
-        .replace("WHERECLAUSE", "where programmeId=:programmeId");
+        .replace("WHERECLAUSE", "where pmem.programmeId=:programmeId");
 
     MapSqlParameterSource paramSource = new MapSqlParameterSource();
     paramSource.addValue("programmeId", programmeId);
@@ -288,7 +288,7 @@ public class PersonElasticSearchService {
 
       String programmeMembershipQuery = sqlQuerySupplier
           .getQuery(SqlQuerySupplier.PROGRAMME_MEMBERSHIP_VIEW)
-          .replace("WHERECLAUSE", "where personId IN (:personIds)");
+          .replace("WHERECLAUSE", "where pmem.personId IN (:personIds)");
 
       List<ProgrammeMembershipDto> programmeMembershipDtos = namedParameterJdbcTemplate
           .query(programmeMembershipQuery,


### PR DESCRIPTION
'...in where clause is ambiguous' SQL errors caused by changes in tis-tcs programmeMembership.sql

NO-TICKET