### PR TITLE
feat: refactor personRecordStatus to use programmeMemberhship

### DIFF
--- a/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
@@ -39,7 +39,7 @@ public class PersonRecordStatusJob {
   private static final Logger LOG = LoggerFactory.getLogger(PersonRecordStatusJob.class);
   private static final int FIFTEEN_MIN = 15 * 60 * 1000;
   private static final String BASE_QUERY =
-      "SELECT DISTINCT personId FROM CurriculumMembership" + " WHERE personId > :lastPersonId"
+      "SELECT DISTINCT personId FROM ProgrammeMembership" + " WHERE personId > :lastPersonId"
           + " AND (programmeEndDate = ':endDate' OR programmeStartDate = ':startDate')"
           + " ORDER BY personId LIMIT :pageSize";
   @Autowired


### PR DESCRIPTION
The `BASE_QUERY` doesn't use any fields in CurriculumMembership, and personId, programmeStartDate, programmeEndDate all should come from ProgrammeMembership.

TIS21-2392