### PR TITLE
Feat: add date argument for person status job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,12 @@
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.17.0</version>
+  <version>1.18.0</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/api/JobResource.java
+++ b/src/main/java/uk/nhs/tis/sync/api/JobResource.java
@@ -77,7 +77,7 @@ public class JobResource {
   @PutMapping("/jobs")
   @PreAuthorize("hasPermission('tis:sync::jobs:', 'Update')")
   public ResponseEntity<Void> runJobsSequentially() {
-    LOG.debug("REST reqeust to run all jobs sequentially");
+    LOG.debug("REST request to run all jobs sequentially");
     CompletableFuture.runAsync(jobRunningListener::runJobs);
     return ResponseEntity.ok().build();
   }
@@ -92,8 +92,9 @@ public class JobResource {
    */
   @PutMapping("/job/{name}")
   @PreAuthorize("hasPermission('tis:sync::jobs:', 'Update')")
-  public ResponseEntity<String> runJob(@PathVariable String name) {
-    LOG.debug("REST reqeust to run job: {}", name);
+  public ResponseEntity<String> runJob(@PathVariable String name,
+      @RequestBody(required = false) String params) {
+    LOG.debug("REST request to run job: {}", name);
     final String ALREADY_RUNNING = "{\"status\":\"already running\"}";
     final String JUST_STARTED = "{\"status\":\"just started\"}";
 
@@ -146,7 +147,12 @@ public class JobResource {
         if (personRecordStatusJob.isCurrentlyRunning()) {
           status = ALREADY_RUNNING;
         } else {
-          personRecordStatusJob.personRecordStatusJob();
+          try {
+            personRecordStatusJob.personRecordStatusJob(params);
+          } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(String.format("{\"error\":\"%s\"}",
+                e.getMessage()));
+          }
         }
         break;
       default:

--- a/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
@@ -61,6 +61,11 @@ public class PersonRecordStatusJob {
     runSyncJob(null);
   }
 
+  /**
+   * trigger the personRecordStatusJob with the specified date.
+   *
+   * @param dateStr can be "ANY", "AWS", empty or a date in format yyyy-MM-dd
+   */
   public void personRecordStatusJob(String dateStr) {
     if (StringUtils.isEmpty(dateStr)) {
       runSyncJob(null);
@@ -79,7 +84,8 @@ public class PersonRecordStatusJob {
   private void validateDateParamFormat(String dateStr) throws DateTimeParseException {
     if (!StringUtils.isEmpty(dateStr) && !StringUtils.equalsIgnoreCase(dateStr, FULL_SYNC_DATE_STR)
         && !StringUtils.equalsIgnoreCase(dateStr, NO_OVERWRITE_TO_AWS_DATE_STR)) {
-      LocalDate.parse(dateStr);
+      // if the date format is incorrect, throw a DateTimeParseException
+      LocalDate parsedDate = LocalDate.parse(dateStr);
     }
   }
 
@@ -156,7 +162,7 @@ public class PersonRecordStatusJob {
           .replace(":pageSize", "" + getPageSize());
     } else {
       queryString = BASE_QUERY.replace(":pageSize", "" + getPageSize())
-          .replace(" AND (programmeEndDate = ':endDate' OR programmeStartDate = ':startDate')", "") + " FOR UPDATE";
+          .replace(" AND (programmeEndDate = ':endDate' OR programmeStartDate = ':startDate')", "");
     }
     int skipped = 0, totalRecords = 0;
     long lastEntityId = 0;
@@ -242,8 +248,7 @@ public class PersonRecordStatusJob {
     } else if (FULL_SYNC_DATE_STR.equalsIgnoreCase(dateInUse)) {
       return null;
     } else {
-      LocalDate a = LocalDate.parse(dateInUse);
-      return a;
+      return LocalDate.parse(dateInUse);
     }
   }
 

--- a/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/PersonRecordStatusJob.java
@@ -16,8 +16,6 @@ import javax.persistence.EntityTransaction;
 import javax.persistence.Query;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,23 +61,13 @@ public class PersonRecordStatusJob {
     runSyncJob(null);
   }
 
-  public void personRecordStatusJob(String params) throws IllegalArgumentException {
-    if (StringUtils.isEmpty(params)) {
+  public void personRecordStatusJob(String dateStr) {
+    if (StringUtils.isEmpty(dateStr)) {
       runSyncJob(null);
     } else {
-      JSONObject jsonParamsObj;
-      String dateStr;
-
       try {
-        jsonParamsObj = new JSONObject(params);
-        dateStr = jsonParamsObj.getString("date");
-      } catch (JSONException e) {
-        String errorMsg = String.format("The param is not a valid JSON string: %s", params);
-        LOG.error(errorMsg);
-        throw new IllegalArgumentException(errorMsg);
-      }
-
-      if (!validateDateParamFormat(dateStr)) {
+        validateDateParamFormat(dateStr);
+      } catch (DateTimeParseException e) {
         String errorMsg = String.format("The date is not correct: %s", dateStr);
         LOG.error(errorMsg);
         throw new IllegalArgumentException(errorMsg);
@@ -88,16 +76,11 @@ public class PersonRecordStatusJob {
     }
   }
 
-  private boolean validateDateParamFormat(String dateStr){
+  private void validateDateParamFormat(String dateStr) throws DateTimeParseException {
     if (!StringUtils.isEmpty(dateStr) && !StringUtils.equalsIgnoreCase(dateStr, FULL_SYNC_DATE_STR)
         && !StringUtils.equalsIgnoreCase(dateStr, NO_OVERWRITE_TO_AWS_DATE_STR)) {
-      try {
-        LocalDate.parse(dateStr);
-      } catch (DateTimeParseException ex) {
-        return false;
-      }
+      LocalDate.parse(dateStr);
     }
-    return true;
   }
 
   protected String getJobName() {

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -12,6 +12,48 @@ function runJob() {
     .then(response => response.json());
 }
 
+function handleErrors(response) {
+  if (!response.ok) {
+     return Promise.reject(response.json());
+  }
+  return response.json();
+}
+
+function runPersonStatusSyncJob() {
+  const jobName = event.srcElement.id;
+  const url = window.location.origin + window.location.pathname + "api/job/" + jobName;
+
+  var date = prompt("Please input the magic date: \n  keep it blank (default) \n  ANY \n  date in format YYYY-MM-DD \n  AWS");
+  if (date === null) { // user clicks cancel button
+    return;
+  }
+  if (!validateDateFormat(date)) {
+    window.alert("Date is not correct!");
+    return;
+  }
+
+  const requestParams = {
+    method : "PUT",
+    body : JSON.stringify({ "date" : date }),
+    headers : { "Content-Type" : "application/json" }
+    };
+
+  fetch(url, requestParams)
+    .then(handleErrors)
+    .catch(errPromise => {
+      errPromise.then(errObj => window.alert(errObj.error));
+    });
+}
+
+function validateDateFormat(param) {
+  var reg = /(19|20)\d\d-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/;
+  if (param === "" || param.toUpperCase() === "ANY"
+    || param.toUpperCase() === "AWS" || param.match(reg)) {
+    return true;
+  }
+  return false;
+}
+
 function runAllJobs() {
   const url = window.location.origin + window.location.pathname + "api/jobs/";
 
@@ -54,7 +96,7 @@ function registerListeners() {
   document.getElementById("postEmployingBodyTrustJob").addEventListener("click", runJob);
   document.getElementById("postTrainingBodyTrustJob").addEventListener("click", runJob);
   document.getElementById("personElasticSearchSyncJob").addEventListener("click", runJob);
-  document.getElementById("personRecordStatusJob").addEventListener("click", runJob);
+  document.getElementById("personRecordStatusJob").addEventListener("click", runPersonStatusSyncJob);
   document.getElementById("runAllJobs").addEventListener("click", runAllJobs);
   document.getElementById("getStatus").addEventListener("click", getStatus);
 }

--- a/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
+++ b/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("JobResource")
 @ExtendWith(SpringExtension.class)
-public class JobResourceTest {
+class JobResourceTest {
 
   @MockBean
   private PersonPlacementEmployingBodyTrustJob personPlacementEmployingBodyTrustJob;
@@ -53,7 +53,7 @@ public class JobResourceTest {
   private MockMvc mockMvc;
 
   @BeforeEach
-  public void setup() {
+  void setup() {
     jobResource = new JobResource(personPlacementEmployingBodyTrustJob,
       personPlacementTrainingBodyTrustJob,
       postEmployingBodyTrustJob,
@@ -66,7 +66,7 @@ public class JobResourceTest {
 
   @DisplayName("get Status")
   @Test
-  public void shouldReturnAllStatusWhenGetStatus() throws Exception {
+  void shouldReturnAllStatusWhenGetStatus() throws Exception {
     when(personPlacementEmployingBodyTrustJob.isCurrentlyRunning())
       .thenReturn(false);
     when(personPlacementTrainingBodyTrustJob.isCurrentlyRunning())
@@ -105,7 +105,7 @@ public class JobResourceTest {
     "personOwnerRebuildJob",
     "personRecordStatusJob"
   })
-  public void shouldReturnJustStartedWhenAJobTriggered(String name) throws Exception {
+  void shouldReturnJustStartedWhenAJobTriggered(String name) throws Exception {
     when(personPlacementTrainingBodyTrustJob.isCurrentlyRunning())
       .thenReturn(false);
     when(personPlacementEmployingBodyTrustJob.isCurrentlyRunning())
@@ -135,7 +135,7 @@ public class JobResourceTest {
       "2022-01-01",
       ""
   })
-  public void shouldReturnJustStartedWhenPersonRecordStatusJobWithCorrectArg(String arg)
+  void shouldReturnJustStartedWhenPersonRecordStatusJobWithCorrectArg(String arg)
       throws Exception {
     when(personRecordStatusJob.isCurrentlyRunning())
         .thenReturn(false);
@@ -154,7 +154,7 @@ public class JobResourceTest {
       "01/01/2020",
       "2022-02-30",
   })
-  public void shouldReturnErrorWhenPersonRecordStatusJobWithCorrectArg(String arg)
+  void shouldReturnErrorWhenPersonRecordStatusJobWithCorrectArg(String arg)
       throws Exception {
     when(personRecordStatusJob.isCurrentlyRunning())
         .thenReturn(false);
@@ -182,7 +182,7 @@ public class JobResourceTest {
     "personOwnerRebuildJob",
     "personRecordStatusJob"
   })
-  public void shouldReturnAlreadyRunningWhenTriggerARunningJob(String name) throws Exception {
+  void shouldReturnAlreadyRunningWhenTriggerARunningJob(String name) throws Exception {
     when(personPlacementTrainingBodyTrustJob.isCurrentlyRunning())
       .thenReturn(true);
     when(personPlacementEmployingBodyTrustJob.isCurrentlyRunning())
@@ -206,7 +206,7 @@ public class JobResourceTest {
 
   @DisplayName("run a nonexistent job")
   @Test
-  public void shouldReturnBadRequestWhenTriggeringANonexistentJob() throws Exception {
+  void shouldReturnBadRequestWhenTriggeringANonexistentJob() throws Exception {
     mockMvc.perform(put("/api/job/" + "nonexistentJob")
         .contentType(MediaType.APPLICATION_JSON))
       .andExpect(status().isBadRequest())

--- a/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
+++ b/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
@@ -127,7 +127,7 @@ public class JobResourceTest {
       .andExpect(jsonPath("$.status").value("just started"));
   }
 
-  @DisplayName("run personRecordStatusJob with date argument")
+  @DisplayName("run personRecordStatusJob with correct date argument")
   @ParameterizedTest(name = "Should return 'just started' status when personRecordStatusJob is triggered with \"{0}\".")
   @ValueSource(strings = {
       "ANY",
@@ -136,7 +136,7 @@ public class JobResourceTest {
       ""
   })
   public void shouldReturnJustStartedWhenPersonRecordStatusJobWithCorrectArg(String arg)
-      throws Exception{
+      throws Exception {
     when(personRecordStatusJob.isCurrentlyRunning())
         .thenReturn(false);
 
@@ -147,7 +147,7 @@ public class JobResourceTest {
         .andExpect(jsonPath("$.status").value("just started"));
   }
 
-  @DisplayName("run personRecordStatusJob with date argument")
+  @DisplayName("run personRecordStatusJob with incorrect date argument")
   @ParameterizedTest(name = "Should return error status when personRecordStatusJob is triggered with \"{0}\".")
   @ValueSource(strings = {
       "aaa",
@@ -155,7 +155,7 @@ public class JobResourceTest {
       "2022-02-30",
   })
   public void shouldReturnErrorWhenPersonRecordStatusJobWithCorrectArg(String arg)
-      throws Exception{
+      throws Exception {
     when(personRecordStatusJob.isCurrentlyRunning())
         .thenReturn(false);
 

--- a/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
@@ -1,11 +1,15 @@
 package uk.nhs.tis.sync.job;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.core.ConditionTimeoutException;
 import org.hamcrest.CoreMatchers;
-import org.junit.Test;
+import org.junit.Assert;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
@@ -18,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @SpringBootTest//?Need this?(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 //TODO Write scripts so we can see some records are being updated.@Sql(scripts = {"/scripts/programmes.sql","/scripts/personRows.sql","/scripts/programmeMemberships.sql"})
 //TODO @Sql(scripts = {"/scripts/deleteProgrammeMemberships.sql","/scripts/deletePersonRows.sql","/scripts/deleteProgrammes.sql"}, executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
-public class PersonRecordStatusJobIntegrationTest {
+class PersonRecordStatusJobIntegrationTest {
 
   @Autowired
   PersonRecordStatusJob job;
@@ -27,18 +31,19 @@ public class PersonRecordStatusJobIntegrationTest {
   private PersonRepository repo;
 
   @Test
-  public void testJobRun() throws Exception {
+  void testJobRun() {
     job.personRecordStatusJob(null);
-    int maxLoops = 1440, loops = 0;
-    //Loop while the job is running up to 2 hours
-    Thread.sleep(1 * 1000L);
-    while (job.isCurrentlyRunning() && loops <= maxLoops) {
-      System.out.println("Job running");
-      Thread.sleep(1 * 1000L);
-      loops++;
+
+    try {
+      await().atLeast(1, TimeUnit.SECONDS)
+          .atMost(2, TimeUnit.HOURS)
+          .with()
+          .pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> !job.isCurrentlyRunning());
+      assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
+    } catch (ConditionTimeoutException e) {
+      Assert.fail("the sync job should not have timed out");
     }
-    assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
-    assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
   }
 
   @DisplayName("run personRecordStatusJob with correct date argument")
@@ -49,18 +54,19 @@ public class PersonRecordStatusJobIntegrationTest {
       "2022-01-01",
       ""
   })
-  public void testJobRunWithCorrectArg(String arg) throws Exception {
+  void testJobRunWithCorrectArg(String arg) {
     job.personRecordStatusJob(arg);
-    int maxLoops = 1440, loops = 0;
-    //Loop while the job is running up to 2 hours
-    Thread.sleep(1 * 1000L);
-    while (job.isCurrentlyRunning() && loops <= maxLoops) {
-      System.out.println("Job running");
-      Thread.sleep(1 * 1000L);
-      loops++;
+
+    try {
+      await().atLeast(1, TimeUnit.SECONDS)
+          .atMost(2, TimeUnit.HOURS)
+          .with()
+          .pollInterval(1, TimeUnit.SECONDS)
+          .until(() -> !job.isCurrentlyRunning());
+      assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
+    } catch (ConditionTimeoutException e) {
+      Assert.fail("the sync job should not have timed out");
     }
-    assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
-    assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
   }
 
   @DisplayName("run personRecordStatusJob with incorrect date argument")
@@ -70,7 +76,7 @@ public class PersonRecordStatusJobIntegrationTest {
       "01/01/2020",
       "2022-02-30",
   })
-  public void testJobShouldThrowExceptionWithIncorrectArg(String arg) {
+  void testJobShouldThrowExceptionWithIncorrectArg(String arg) {
     Exception exception = assertThrows(IllegalArgumentException.class, () -> job.personRecordStatusJob(arg));
     String errMsg = exception.getMessage();
     assertThat("should the sync job is not currently running",

--- a/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
@@ -23,7 +23,7 @@ public class PersonRecordStatusJobIntegrationTest {
 
   @Test
   public void testJobRun() throws Exception {
-    job.personRecordStatusJob();
+    job.personRecordStatusJob(null);
     int maxLoops = 1440, loops = 0;
     //Loop while the job is running up to 2 hours
     Thread.sleep(1 * 1000L);
@@ -35,5 +35,4 @@ public class PersonRecordStatusJobIntegrationTest {
     Assert.assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
     Assert.assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
   }
-
 }

--- a/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
+++ b/src/test/java/uk/nhs/tis/sync/job/PersonRecordStatusJobIntegrationTest.java
@@ -1,13 +1,18 @@
 package uk.nhs.tis.sync.job;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.transformuk.hee.tis.tcs.service.repository.PersonRepository;
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest//?Need this?(classes = Application.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -32,7 +37,45 @@ public class PersonRecordStatusJobIntegrationTest {
       Thread.sleep(1 * 1000L);
       loops++;
     }
-    Assert.assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
-    Assert.assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
+    assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
+    assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
+  }
+
+  @DisplayName("run personRecordStatusJob with correct date argument")
+  @ParameterizedTest(name = "Should return run job when it is triggered with \"{0}\".")
+  @ValueSource(strings = {
+      "ANY",
+      "AWS",
+      "2022-01-01",
+      ""
+  })
+  public void testJobRunWithCorrectArg(String arg) throws Exception {
+    job.personRecordStatusJob(arg);
+    int maxLoops = 1440, loops = 0;
+    //Loop while the job is running up to 2 hours
+    Thread.sleep(1 * 1000L);
+    while (job.isCurrentlyRunning() && loops <= maxLoops) {
+      System.out.println("Job running");
+      Thread.sleep(1 * 1000L);
+      loops++;
+    }
+    assertThat("should the sync job is not currently running", job.isCurrentlyRunning(), CoreMatchers.not(true));
+    assertThat("then the sync job should not have timed out", loops > maxLoops, CoreMatchers.not(true));
+  }
+
+  @DisplayName("run personRecordStatusJob with incorrect date argument")
+  @ParameterizedTest(name = "Should throw exception when personRecordStatusJob is triggered with \"{0}\".")
+  @ValueSource(strings = {
+      "aaa",
+      "01/01/2020",
+      "2022-02-30",
+  })
+  public void testJobShouldThrowExceptionWithIncorrectArg(String arg) {
+    Exception exception = assertThrows(IllegalArgumentException.class, () -> job.personRecordStatusJob(arg));
+    String errMsg = exception.getMessage();
+    assertThat("should the sync job is not currently running",
+        job.isCurrentlyRunning(), CoreMatchers.not(true));
+    assertThat("should throw exception for the incorrect date argument",
+        errMsg, CoreMatchers.containsString("The date is not correct"));
   }
 }


### PR DESCRIPTION
1. add date argument for person status job
arguments allowed(case insensitive): "ANY" (to trigger full sync), "AWS" (to use the param from AWS Parameter Store), keep it blank (default option, to trigger the job based on current date), a date in format "yyyy-MM-dd" (to specify a date). Will update the Readme in the next PR.
2. update frontend page to ask for user input
3. the date argument is validated in both frontend and backend
4. add and fix some tests