### PR TITLE
fix: close EntityManager before replacing

### DIFF
--- a/src/main/java/uk/nhs/tis/sync/job/TrustAdminSyncJobTemplate.java
+++ b/src/main/java/uk/nhs/tis/sync/job/TrustAdminSyncJobTemplate.java
@@ -116,6 +116,7 @@ public abstract class TrustAdminSyncJobTemplate<E> implements RunnableJob {
         transaction.commit();
         LOG.info("Time taken to save chunk : [{}]", stopwatch);
         stopwatch.reset().start();
+        entityManager.close();
       }
       LOG.info("Sync job [{}] finished. Total time taken {} for processing [{}] records",
           getJobName(), mainStopWatch.stop(), totalRecords);


### PR DESCRIPTION
`EntityManager`s are replaced each chunk (we should revisit this). It was refactored earlier but was not explicitly closed before being reassigned.

TIS21-3311: PersonStatus not updated when current programme is deleted