### PR TITLE
fix:internal parameter names for rabbitmq

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -114,19 +114,19 @@
           "valueFrom": "sqs-queue-url-sync-${environment}"
         },
         {
-          "name": "REVAL_RABBITMQ_HOST",
+          "name": "RABBITMQ_HOST",
           "valueFrom": "reval-rabbitmq-host-sync-${environment}"
         },
         {
-          "name": "REVAL_RABBITMQ_PORT",
+          "name": "RABBITMQ_PORT",
           "valueFrom": "reval-rabbitmq-port-sync-${environment}"
         },
         {
-          "name": "REVAL_RABBITMQ_USERNAME",
+          "name": "RABBITMQ_USERNAME",
           "valueFrom": "reval-rabbitmq-username-sync-${environment}"
         },
         {
-          "name": "REVAL_RABBITMQ_PASSWORD",
+          "name": "RABBITMQ_PASSWORD",
           "valueFrom": "reval-rabbitmq-password-sync-${environment}"
         },
         {


### PR DESCRIPTION
TIS21-3229

In application.yml, the config for rabbitmq doesn't have the prefix, so remove them. 
https://github.com/Health-Education-England/TIS-SYNC/blob/bdf89db2595f3a126550f33d17992f6ba3e67450/src/main/resources/config/application.yml#L126
