### PR TITLE
fix:remove RevalCurrentPmSyncJob from nimdta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.19.0</version>
+  <version>1.19.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/api/JobResource.java
+++ b/src/main/java/uk/nhs/tis/sync/api/JobResource.java
@@ -3,11 +3,10 @@ package uk.nhs.tis.sync.api;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -49,8 +48,8 @@ public class JobResource {
   private RevalCurrentPmSyncJob revalCurrentPmSyncJob;
   @Autowired
   private JobRunningListener jobRunningListener;
-  @Autowired
-  private Environment environment;
+  @Value("${spring.profiles.active:}")
+  private String activeProfile;
 
   public JobResource(PersonPlacementEmployingBodyTrustJob personPlacementEmployingBodyTrustJob,
       PersonPlacementTrainingBodyTrustJob personPlacementTrainingBodyTrustJob,
@@ -59,7 +58,7 @@ public class JobResource {
       PersonElasticSearchSyncJob personElasticSearchSyncJob,
       PersonOwnerRebuildJob personOwnerRebuildJob,
       PersonRecordStatusJob personRecordStatusJob
-      ) {
+  ) {
     this.personPlacementEmployingBodyTrustJob = personPlacementEmployingBodyTrustJob;
     this.personPlacementTrainingBodyTrustJob = personPlacementTrainingBodyTrustJob;
     this.postEmployingBodyTrustJob = postEmployingBodyTrustJob;
@@ -101,8 +100,7 @@ public class JobResource {
 
   @GetMapping("/sys/profile")
   public ResponseEntity<String> getSysProfile() {
-    String[] profiles = environment.getActiveProfiles();
-    return ResponseEntity.ok(StringUtils.join(profiles, ";"));
+    return ResponseEntity.ok(this.activeProfile);
   }
 
   /**

--- a/src/main/java/uk/nhs/tis/sync/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/tis/sync/config/RabbitConfig.java
@@ -8,10 +8,12 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 /**
  * Configuration for RabbitMQ messaging.
  */
+@Profile("!nimdta")
 @Configuration
 public class RabbitConfig {
 

--- a/src/main/java/uk/nhs/tis/sync/event/listener/JobRunningListener.java
+++ b/src/main/java/uk/nhs/tis/sync/event/listener/JobRunningListener.java
@@ -48,12 +48,16 @@ public class JobRunningListener implements ApplicationListener<ApplicationReadyE
   @Autowired
   private PersonElasticSearchSyncJob personElasticSearchSyncJob;
 
-  @Autowired
   private RevalCurrentPmSyncJob revalCurrentPmSyncJob;
 
   private LocalTime earliest;
 
   private LocalTime latest;
+
+  @Autowired(required = false)
+  public void setRevalCurrentPmSyncJob(RevalCurrentPmSyncJob revalCurrentPmSyncJob) {
+    this.revalCurrentPmSyncJob = revalCurrentPmSyncJob;
+  }
 
   @Override
   public void onApplicationEvent(ApplicationReadyEvent event) {
@@ -95,10 +99,12 @@ public class JobRunningListener implements ApplicationListener<ApplicationReadyE
       do {
         Thread.sleep(SLEEP_DURATION);
       } while (personElasticSearchSyncJob.isCurrentlyRunning());
-      revalCurrentPmSyncJob.revalCurrentPmSyncJob();
-      do {
-        Thread.sleep(SLEEP_DURATION);
-      } while (revalCurrentPmSyncJob.isCurrentlyRunning());
+      if (revalCurrentPmSyncJob != null) {
+        revalCurrentPmSyncJob.revalCurrentPmSyncJob();
+        do {
+          Thread.sleep(SLEEP_DURATION);
+        } while (revalCurrentPmSyncJob.isCurrentlyRunning());
+      }
     } catch (InterruptedException e) {
       LOG.error(e.getMessage(), e);
     }

--- a/src/main/java/uk/nhs/tis/sync/job/reval/RevalCurrentPmSyncJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/reval/RevalCurrentPmSyncJob.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import net.javacrumbs.shedlock.core.SchedulerLock;
 import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,6 +18,7 @@ import uk.nhs.tis.sync.message.publisher.RabbitMqTcsPmUpdatePublisher;
  * Get personIds whose current programmeMembership changes nightly. And sends messages to rabbitMq
  * for tcs to fetch
  */
+@Profile("!nimdta")
 @Component
 @ManagedResource(objectName = "sync.mbean:name=RevalCurrentPmSyncJob",
     description = "Job message personIds if their programme membership(s) started/ended")
@@ -33,6 +35,7 @@ public class RevalCurrentPmSyncJob extends PersonCurrentPmSyncJobTemplate<Long> 
     revalCurrentPmSyncJob();
   }
 
+  @Profile("!nimdta")
   @Scheduled(cron = "${application.cron.revalCurrentPmJob}")
   @SchedulerLock(name = "revalCurrentPmScheduledTask", lockAtLeastFor = FIFTEEN_MIN,
       lockAtMostFor = FIFTEEN_MIN)

--- a/src/main/java/uk/nhs/tis/sync/message/publisher/RabbitMqTcsPmUpdatePublisher.java
+++ b/src/main/java/uk/nhs/tis/sync/message/publisher/RabbitMqTcsPmUpdatePublisher.java
@@ -4,11 +4,13 @@ import java.util.Set;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
  * publish messages to rabbitMq queues.
  */
+@Profile("!nimdta")
 @Component
 public class RabbitMqTcsPmUpdatePublisher {
 

--- a/src/main/resources/config/application-local.yml
+++ b/src/main/resources/config/application-local.yml
@@ -14,6 +14,12 @@ spring:
       uris: ${ES_URLS:http://localhost:9200}
   jpa:
     show_sql: false
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USERNAME:guest}
+    password: ${RABBITMQ_PASSWORD:guest}
+    ssl.enabled: ${RABBITMQ_USE_SSL:false}
 
 logging:
   file: ${LOG_DIR:${HOME}}/sync.log

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -123,11 +123,11 @@ spring:
   cache:
     caffeine.spec: maximumSize=100,expireAfterAccess=1m
   rabbitmq:
-    host: ${RABBITMQ_HOST:localhost}
-    port: ${RABBITMQ_PORT:5672}
-    username: ${RABBITMQ_USERNAME:guest}
-    password: ${RABBITMQ_PASSWORD:guest}
-    ssl.enabled: ${RABBITMQ_USE_SSL:false}
+    host: ${RABBITMQ_HOST}
+    port: ${RABBITMQ_PORT}
+    username: ${RABBITMQ_USERNAME}
+    password: ${RABBITMQ_PASSWORD}
+    ssl.enabled: ${RABBITMQ_USE_SSL}
 
 server:
   port: 8101

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -46,15 +46,17 @@
   </div>
 </div>
 <br>
-<div class="help"><text>Synchronisation jobs for Revalidation:</text></div><br>
-<div>
-  <div class="container-8">
-    <h2 class="box-1">Reval current programme membership job</h2>
-    <button type="button" id="revalCurrentPmJob" class="box-2">Run job</button>
-    <p id="revalCurrentPmJob_status" class="box-3"></p>
+<div id="reval-panel" class="hidden">
+  <div class="help"><text>Synchronisation jobs for Revalidation:</text></div><br>
+  <div>
+    <div class="container-8">
+      <h2 class="box-1">Reval current programme membership job</h2>
+      <button type="button" id="revalCurrentPmJob" class="box-2">Run job</button>
+      <p id="revalCurrentPmJob_status" class="box-3"></p>
+    </div>
   </div>
+  <br>
 </div>
-<br>
 <div>
   <div class="jobs-status-buttons">
     <button type="button" id="runAllJobs">Run All Jobs</button>

--- a/src/main/resources/static/main.js
+++ b/src/main/resources/static/main.js
@@ -116,7 +116,22 @@ function setStatusForRevalCurrentPMJob() {
   revalCurrentPmJobElement.classList.remove("running-text");
 }
 
+function fetchSysProfile() {
+  var profile = "default";
+  const url = window.location.origin + window.location.pathname + "api/sys/profile";
+
+  fetch(url)
+    .then(response => response.text())
+    .then(data => {
+      profile = data;
+      if (profile.indexOf("nimdta") === -1) {
+        document.getElementById("reval-panel").classList.remove("hidden");
+      }
+    });
+}
+
 function registerListeners() {
+  fetchSysProfile();
   document.getElementById("personOwnerRebuildJob").addEventListener("click", runJob);
   document.getElementById("personPlacementEmployingBodyTrustJob").addEventListener("click", runJob);
   document.getElementById("personPlacementTrainingBodyTrustJob").addEventListener("click", runJob);

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -90,3 +90,7 @@ button:hover{
   font-size:1.2em;
   font-weight:bold;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
+++ b/src/test/java/uk/nhs/tis/sync/api/JobResourceTest.java
@@ -67,8 +67,8 @@ class JobResourceTest {
         postTrainingBodyTrustJob,
         personElasticSearchSyncJob,
         personOwnerRebuildJob,
-        personRecordStatusJob,
-        revalCurrentPmSyncJob);
+        personRecordStatusJob);
+    jobResource.setRevalCurrentPmSyncJob(revalCurrentPmSyncJob);
     mockMvc = MockMvcBuilders.standaloneSetup(jobResource).build();
   }
 
@@ -200,6 +200,7 @@ class JobResourceTest {
       "revalCurrentPmJob"
   })
   void shouldReturnAlreadyRunningWhenTriggerARunningJob(String name) throws Exception {
+
     when(personPlacementTrainingBodyTrustJob.isCurrentlyRunning())
         .thenReturn(true);
     when(personPlacementEmployingBodyTrustJob.isCurrentlyRunning())

--- a/src/test/java/uk/nhs/tis/sync/event/listener/JobRunningListenerTest.java
+++ b/src/test/java/uk/nhs/tis/sync/event/listener/JobRunningListenerTest.java
@@ -10,8 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.nhs.tis.sync.job.PersonOwnerRebuildJob;
-import uk.nhs.tis.sync.job.RecordResendingJob;
 import uk.nhs.tis.sync.job.person.PersonElasticSearchSyncJob;
+import uk.nhs.tis.sync.job.reval.RevalCurrentPmSyncJob;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -24,6 +24,8 @@ public class JobRunningListenerTest {
   private PersonElasticSearchSyncJob personElasticSearchSyncJob;
   @MockBean
   private PersonOwnerRebuildJob personOwnerRebuildJob;
+  @MockBean
+  private RevalCurrentPmSyncJob revalCurrentPmSyncJob;
 
   @Autowired
   JobRunningListener testClass;
@@ -32,10 +34,12 @@ public class JobRunningListenerTest {
   public void testRunJobs() {
     when(personOwnerRebuildJob.isCurrentlyRunning()).thenReturn(false);
     when(personElasticSearchSyncJob.isCurrentlyRunning()).thenReturn(false);
+    when(revalCurrentPmSyncJob.isCurrentlyRunning()).thenReturn(false);
     testClass.runJobs();
     verify(personOwnerRebuildJob).personOwnerRebuildJob();
     verify(personOwnerRebuildJob).isCurrentlyRunning();
     verify(personElasticSearchSyncJob).personElasticSearchSync();
     verify(personElasticSearchSyncJob).isCurrentlyRunning();
+    verify(revalCurrentPmSyncJob).isCurrentlyRunning();
   }
 }


### PR DESCRIPTION
Use `@Profile("!nimdta")` instead of "@ConditionXXX" to make everywhere consistent. I believe this would be easier for us to locate them in the future. But it requires the profile to contain `nimdta` first. 

depends on [TIS-OPS#507](https://github.com/Health-Education-England/TIS-OPS/pull/507)

TIS21-3229