### PR TITLE
feat: handle PM and CM data requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.19.2</version>
+  <version>1.20.0</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-client</artifactId>
-      <version>6.0.2</version>
+      <version>6.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/src/main/java/uk/nhs/tis/sync/dto/CurriculumMembershipDmsDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/CurriculumMembershipDmsDto.java
@@ -6,7 +6,6 @@ import lombok.Data;
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CurriculumMembershipDmsDto {
-  //CurriculumMembership details
   private String id;
   private String curriculumStartDate;
   private String curriculumEndDate;
@@ -16,17 +15,4 @@ public class CurriculumMembershipDmsDto {
   private String intrepidId;
   private String programmeMembershipUuid;
   private String amendedDate;
-
-  //ProgrammeMembership details
-  private String personId;
-  private String programmeId;
-  private String rotationId;
-  private String rotation;
-  private String trainingNumberId;
-  private String trainingPathway;
-  private String programmeMembershipType;
-  private String programmeStartDate;
-  private String programmeEndDate;
-  private String leavingReason;
-  private String leavingDestination;
 }

--- a/src/main/java/uk/nhs/tis/sync/dto/CurriculumMembershipWrapperDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/CurriculumMembershipWrapperDto.java
@@ -1,0 +1,15 @@
+package uk.nhs.tis.sync.dto;
+
+import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
+import java.util.UUID;
+import lombok.Value;
+
+/**
+ * A wrapper for {@link CurriculumMembershipDTO} to allow the inclusion of the PM UUID.
+ */
+@Value
+public class CurriculumMembershipWrapperDto {
+
+  UUID programmeMembershipUuid;
+  CurriculumMembershipDTO curriculumMembership;
+}

--- a/src/main/java/uk/nhs/tis/sync/dto/DmsDtoType.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/DmsDtoType.java
@@ -19,6 +19,7 @@ import com.transformuk.hee.tis.tcs.api.dto.SpecialtyDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import uk.nhs.tis.sync.mapper.CurriculumMapper;
+import uk.nhs.tis.sync.mapper.CurriculumMembershipMapper;
 import uk.nhs.tis.sync.mapper.DmsMapper;
 import uk.nhs.tis.sync.mapper.GradeMapper;
 import uk.nhs.tis.sync.mapper.PersonMapper;
@@ -42,6 +43,8 @@ public enum DmsDtoType {
 
   CONTACT_DETAILS(ContactDetailsDTO.class, "tcs", "ContactDetails", null),
   CURRICULUM(CurriculumDTO.class, "tcs", "Curriculum", CurriculumMapper.class),
+  CURRICULUM_MEMBERSHIP(CurriculumMembershipWrapperDto.class, "tcs", "CurriculumMembership",
+      CurriculumMembershipMapper.class),
   GDC_DETAILS(GdcDetailsDTO.class, "tcs", "GdcDetails", null),
   GMC_DETAILS(GmcDetailsDTO.class, "tcs", "GmcDetails", null),
   GRADE(GradeDTO.class, "reference", "Grade", GradeMapper.class),
@@ -52,7 +55,7 @@ public enum DmsDtoType {
       PlacementSpecialtyMapper.class),
   POST(PostDTO.class, "tcs", "Post", PostMapper.class),
   PROGRAMME(ProgrammeDTO.class, "tcs", "Programme", ProgrammeMapper.class),
-  PROGRAMME_MEMBERSHIP(ProgrammeMembershipDTO.class, "tcs", "CurriculumMembership",
+  PROGRAMME_MEMBERSHIP(ProgrammeMembershipDTO.class, "tcs", "ProgrammeMembership",
       ProgrammeMembershipMapper.class),
   QUALIFICATION(QualificationDTO.class, "tcs", "Qualification", QualificationMapper.class),
   SITE(SiteDTO.class, "reference", "Site", SiteMapper.class),

--- a/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
@@ -1,0 +1,27 @@
+package uk.nhs.tis.sync.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.UUID;
+import lombok.Data;
+
+/**
+ * A DTO for transferring Programme Membership data via Amazon DMS.
+ */
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ProgrammeMembershipDmsDto {
+
+  private UUID uuid;
+  private String personId;
+  private String programmeId;
+  private String rotationId;
+  private String rotation;
+  private String trainingNumberId;
+  private String programmeMembershipType;
+  private String programmeStartDate;
+  private String programmeEndDate;
+  private String leavingReason;
+  private String trainingPathway;
+  private String amendedDate;
+  private String leavingDestination;
+}

--- a/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
@@ -1,43 +1,40 @@
 package uk.nhs.tis.sync.mapper;
 
-import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
+import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import uk.nhs.tis.sync.dto.CurriculumMembershipDmsDto;
+import uk.nhs.tis.sync.dto.CurriculumMembershipWrapperDto;
 
 @Mapper(componentModel = "spring")
 public interface CurriculumMembershipMapper extends
-    DmsMapper<CurriculumMembershipDTO, CurriculumMembershipDmsDto> {
+    DmsMapper<CurriculumMembershipWrapperDto, CurriculumMembershipDmsDto> {
 
   /**
    * Converts a CurriculumMembershipDTO to a CurriculumMembershipDmsDto.
    *
-   * @param curriculumMembershipDto the CurriculumMembershipDTO to convert
+   * @param curriculumMembershipWrapperDto the FindBetterNameDto to convert
    * @return the CurriculumMembershipDmsDto
    */
-  @Mapping(target = "rotation", ignore = true)
-  @Mapping(target = "rotationId", ignore = true)
-  @Mapping(target = "programmeMembershipUuid", ignore = true)
-  @Mapping(target = "personId", ignore = true)
-  @Mapping(target = "programmeId", ignore = true)
-  @Mapping(target = "trainingNumberId", ignore = true)
-  @Mapping(target = "trainingPathway", ignore = true)
-  @Mapping(target = "programmeMembershipType", ignore = true)
-  @Mapping(target = "programmeStartDate", ignore = true)
-  @Mapping(target = "programmeEndDate", ignore = true)
-  @Mapping(target = "leavingReason", ignore = true)
-  @Mapping(target = "leavingDestination", ignore = true)
-  CurriculumMembershipDmsDto toDmsDto(CurriculumMembershipDTO curriculumMembershipDto);
+  @Mapping(target = "id", source = "curriculumMembership.id")
+  @Mapping(target = "curriculumStartDate", source = "curriculumMembership.curriculumStartDate")
+  @Mapping(target = "curriculumEndDate", source = "curriculumMembership.curriculumEndDate")
+  @Mapping(target = "curriculumCompletionDate", source = "curriculumMembership.curriculumCompletionDate")
+  @Mapping(target = "periodOfGrace", source = "curriculumMembership.periodOfGrace")
+  @Mapping(target = "curriculumId", source = "curriculumMembership.curriculumId")
+  @Mapping(target = "intrepidId", source = "curriculumMembership.intrepidId")
+  @Mapping(target = "programmeMembershipUuid")
+  @Mapping(target = "amendedDate", source = "curriculumMembership.amendedDate")
+  CurriculumMembershipDmsDto toDmsDto(
+      CurriculumMembershipWrapperDto curriculumMembershipWrapperDto);
 
-  @Mapping(target = "id", ignore = true)
-  @Mapping(target = "curriculumStartDate", ignore = true)
-  @Mapping(target = "curriculumEndDate", ignore = true)
-  @Mapping(target = "curriculumCompletionDate", ignore = true)
-  @Mapping(target = "periodOfGrace", ignore = true)
-  @Mapping(target = "curriculumId", ignore = true)
-  @Mapping(target = "intrepidId", ignore = true)
-  @Mapping(target = "amendedDate", ignore = true)
-  CurriculumMembershipDmsDto update(@MappingTarget CurriculumMembershipDmsDto target,
-                                    CurriculumMembershipDmsDto source);
+  /**
+   * Maps a UUID to string.
+   *
+   * @param source The UUID to map.
+   * @return The string value of the UUID.
+   */
+  default String map(UUID source) {
+    return source == null ? null : source.toString();
+  }
 }

--- a/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
@@ -1,81 +1,43 @@
 package uk.nhs.tis.sync.mapper;
 
-import com.transformuk.hee.tis.tcs.api.dto.CurriculumMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
-import uk.nhs.tis.sync.dto.CurriculumMembershipDmsDto;
+import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
 
 @Mapper(componentModel = "spring")
 public interface ProgrammeMembershipMapper extends
-    DmsMapper<ProgrammeMembershipDTO, CurriculumMembershipDmsDto> {
+    DmsMapper<ProgrammeMembershipDTO, ProgrammeMembershipDmsDto> {
 
   /**
-   * Converts a ProgrammeMembershipDTO to a CurriculumMembershipDmsDto.
+   * Converts a ProgrammeMembershipDTO to a ProgrammeMembershipDmsDto.
    *
    * @param programmeMembershipDto the ProgrammeMembershipDTO to convert
-   * @return the CurriculumMembershipDmsDto
+   * @return the ProgrammeMembershipDmsDto
    */
-
-  @Mapping(target = "rotation", source = "rotation.name")
-  @Mapping(target = "rotationId", source = "rotation.id")
-  @Mapping(target = "programmeMembershipUuid", source = "uuid",
-      qualifiedByName = "getProgrammeMembershipUuid")
+  @Mapping(target = "uuid")
   @Mapping(target = "personId", source = "person.id")
+  @Mapping(target = "programmeId")
+  @Mapping(target = "rotationId", source = "rotation.id")
+  @Mapping(target = "rotation", source = "rotation.name")
   @Mapping(target = "trainingNumberId", source = "trainingNumber.id")
-  @Mapping(target = "programmeMembershipType", source = "programmeMembershipType",
-      qualifiedByName = "getProgrammeMembershipType")
-  @Mapping(target = "curriculumStartDate", ignore = true)
-  @Mapping(target = "curriculumEndDate", ignore = true)
-  @Mapping(target = "curriculumCompletionDate", ignore = true)
-  @Mapping(target = "periodOfGrace", ignore = true)
-  @Mapping(target = "curriculumId", ignore = true)
-  @Mapping(target = "intrepidId", ignore = true)
-  CurriculumMembershipDmsDto toDmsDto(ProgrammeMembershipDTO programmeMembershipDto);
-
-  @Named("getProgrammeMembershipUuid")
-  default String getProgrammeMembershipUuid(UUID uuid) {
-    if (uuid != null) {
-      return uuid.toString();
-    }
-    return null;
-  }
-
-  @Named("getProgrammeMembershipType")
-  default String getProgrammeMembershipType(ProgrammeMembershipType programmeMembershipType) {
-    if (programmeMembershipType != null) {
-      return programmeMembershipType.toString();
-    }
-    return null;
-  }
+  @Mapping(target = "programmeMembershipType")
+  @Mapping(target = "programmeStartDate")
+  @Mapping(target = "programmeEndDate")
+  @Mapping(target = "leavingReason")
+  @Mapping(target = "trainingPathway")
+  @Mapping(target = "amendedDate")
+  @Mapping(target = "leavingDestination")
+  ProgrammeMembershipDmsDto toDmsDto(ProgrammeMembershipDTO programmeMembershipDto);
 
   /**
-   * Builds a list of DmsDtos from a programme membership's curriculum memberships.
+   * Maps a ProgrammeMembershipType to string.
    *
-   * <p>Each will have details from the parent programme membership, as well as curriculum
-   * membership-specific information.</p>
-   *
-   * @param pmDto the ProgrammeMembershipDTO to process
-   * @return a list of CurriculumMembershipDmsDtos
+   * @param source The programme membership type to map.
+   * @return The string value of the programme membership type.
    */
-  @Override
-  default List<CurriculumMembershipDmsDto> toListDmsDto(ProgrammeMembershipDTO pmDto) {
-    List<CurriculumMembershipDmsDto> dmsDtos = new ArrayList<>();
-    CurriculumMembershipDmsDto dmsDtoFromPm = toDmsDto(pmDto);
-    CurriculumMembershipMapper curriculumMembershipMapper = new CurriculumMembershipMapperImpl();
-
-    for (CurriculumMembershipDTO cm : pmDto.getCurriculumMemberships()) {
-      CurriculumMembershipDmsDto dmsDto = curriculumMembershipMapper.toDmsDto(cm);
-      if (dmsDto != null) {
-        curriculumMembershipMapper.update(dmsDto, dmsDtoFromPm);
-        dmsDtos.add(dmsDto);
-      }
-    }
-    return dmsDtos;
+  default String map(ProgrammeMembershipType source) {
+    return source == null ? null : source.toString();
   }
 }

--- a/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
+++ b/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
@@ -4,6 +4,7 @@ import com.transformuk.hee.tis.reference.client.impl.ReferenceServiceImpl;
 import com.transformuk.hee.tis.tcs.api.dto.PersonDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementDetailsDTO;
 import com.transformuk.hee.tis.tcs.api.dto.PlacementSpecialtyDTO;
+import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.PostSpecialtyType;
 import com.transformuk.hee.tis.tcs.client.service.impl.TcsServiceImpl;
 import java.util.ArrayList;
@@ -11,21 +12,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.nhs.tis.sync.dto.CurriculumMembershipWrapperDto;
 
 @Slf4j
 @Service
 public class DataRequestService {
 
   private static final String TABLE_CURRICULUM = "Curriculum";
+  private static final String TABLE_CURRICULUM_MEMBERSHIP = "CurriculumMembership";
   private static final String TABLE_GRADE = "Grade";
   private static final String TABLE_PERSON = "Person";
   private static final String TABLE_PLACEMENT = "Placement";
   private static final String TABLE_PLACEMENT_SPECIALTY = "PlacementSpecialty";
   private static final String TABLE_POST = "Post";
   private static final String TABLE_PROGRAMME = "Programme";
+  private static final String TABLE_PROGRAMME_MEMBERSHIP = "ProgrammeMembership";
   private static final String TABLE_SPECIALTY = "Specialty";
   private static final String TABLE_SITE = "Site";
   private static final String TABLE_TRUST = "Trust";
@@ -51,6 +56,22 @@ public class DataRequestService {
       if (table.equals(TABLE_PLACEMENT_SPECIALTY) && message.containsKey("placementId")) {
         long placementId = Long.parseLong(message.get("placementId"));
         return createNonNullList(retrievePlacementSpecialty(placementId));
+      }
+
+      if (table.equals(TABLE_PROGRAMME_MEMBERSHIP) && message.containsKey("uuid")) {
+        UUID uuid = UUID.fromString(message.get("uuid"));
+        return createNonNullList(tcsServiceImpl.getProgrammeMembershipByUuid(uuid));
+      }
+
+      if (table.equals(TABLE_CURRICULUM_MEMBERSHIP) && message.containsKey(
+          "programmeMembershipUuid")) {
+        UUID uuid = UUID.fromString(message.get("programmeMembershipUuid"));
+        ProgrammeMembershipDTO programmeMembership = tcsServiceImpl.getProgrammeMembershipByUuid(
+            uuid);
+
+        return programmeMembership.getCurriculumMemberships().stream()
+            .map(cm -> new CurriculumMembershipWrapperDto(uuid, cm))
+            .collect(Collectors.toList());
       }
 
       if (message.containsKey("id")) {

--- a/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
@@ -42,6 +42,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.time.DateUtils;
@@ -50,14 +51,16 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import uk.nhs.tis.sync.dto.CurriculumDmsDto;
 import uk.nhs.tis.sync.dto.CurriculumMembershipDmsDto;
+import uk.nhs.tis.sync.dto.CurriculumMembershipWrapperDto;
 import uk.nhs.tis.sync.dto.DmsDto;
 import uk.nhs.tis.sync.dto.GradeDmsDto;
 import uk.nhs.tis.sync.dto.MetadataDto;
 import uk.nhs.tis.sync.dto.PersonDmsDto;
-import uk.nhs.tis.sync.dto.PlacementSummaryDmsDto;
 import uk.nhs.tis.sync.dto.PlacementSpecialtyDmsDto;
+import uk.nhs.tis.sync.dto.PlacementSummaryDmsDto;
 import uk.nhs.tis.sync.dto.PostDmsDto;
 import uk.nhs.tis.sync.dto.ProgrammeDmsDto;
+import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
 import uk.nhs.tis.sync.dto.QualificationDmsDto;
 import uk.nhs.tis.sync.dto.SiteDmsDto;
 import uk.nhs.tis.sync.dto.SpecialtyDmsDto;
@@ -284,7 +287,73 @@ class DmsRecordAssemblerTest {
   }
 
   @Test
-  void shouldAssembleTwoDmsDtosWhenGivenAProgrammeMembershipDtoWithTwoCurriculumMemberships() {
+  void shouldAssembleCurriculumMembership() {
+    CurriculumMembershipDTO curriculumMembershipDto = new CurriculumMembershipDTO();
+    curriculumMembershipDto.setCurriculumId(4L);
+    curriculumMembershipDto.setId(1111L);
+    curriculumMembershipDto.setCurriculumStartDate(LocalDate.of(2021, 2, 2));
+    curriculumMembershipDto.setCurriculumEndDate(LocalDate.of(2022, 1, 1));
+    curriculumMembershipDto.setCurriculumCompletionDate(LocalDate.of(2022, 1, 2));
+    curriculumMembershipDto.setPeriodOfGrace(5);
+    curriculumMembershipDto.setIntrepidId("12345");
+    curriculumMembershipDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
+
+    CurriculumMembershipWrapperDto curriculumMembershipWrapperDto = new CurriculumMembershipWrapperDto(
+        UUID.fromString("123e4567-e89b-12d3-a456-426614174000"), curriculumMembershipDto);
+
+    //when
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(
+        curriculumMembershipWrapperDto));
+
+    //then
+    assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
+    DmsDto dmsDto = dmsDtos.get(0);
+
+    Object data = dmsDto.getData();
+    assertThat("Unexpected data.", data, instanceOf(CurriculumMembershipDmsDto.class));
+
+    CurriculumMembershipDmsDto curriculumMembershipDmsDto = (CurriculumMembershipDmsDto) data;
+    assertThat("Unexpected id.",
+        curriculumMembershipDmsDto.getId(),
+        is("1111"));
+    assertThat("Unexpected curriculum start date.",
+        curriculumMembershipDmsDto.getCurriculumStartDate(),
+        is("2021-02-02"));
+    assertThat("Unexpected curriculum end date.",
+        curriculumMembershipDmsDto.getCurriculumEndDate(),
+        is("2022-01-01"));
+    assertThat("Unexpected curriculum completion date.",
+        curriculumMembershipDmsDto.getCurriculumCompletionDate(),
+        is("2022-01-02"));
+    assertThat("Unexpected period of grace.",
+        curriculumMembershipDmsDto.getPeriodOfGrace(),
+        is("5"));
+    assertThat("Unexpected curriculum id.",
+        curriculumMembershipDmsDto.getCurriculumId(),
+        is("4"));
+    assertThat("Unexpected intrepid id.",
+        curriculumMembershipDmsDto.getIntrepidId(),
+        is("12345"));
+    assertThat("Unexpected amended date.",
+        curriculumMembershipDmsDto.getAmendedDate(),
+        is(LocalDateTime.of(2021, 1, 1, 1, 1, 1).toString()));
+    assertThat("Unexpected programme membership UUID.",
+        curriculumMembershipDmsDto.getProgrammeMembershipUuid(),
+        is("123e4567-e89b-12d3-a456-426614174000"));
+
+    MetadataDto metadata = dmsDto.getMetadata();
+    assertThat("Unexpected timestamp.", metadata.getTimestamp(), notNullValue());
+    assertThat("Unexpected record type.", metadata.getRecordType(), is("data"));
+    assertThat("Unexpected operation.", metadata.getOperation(), is("load"));
+    assertThat("Unexpected partition key type.", metadata.getPartitionKeyType(),
+        is("schema-table"));
+    assertThat("Unexpected schema.", metadata.getSchemaName(), is("tcs"));
+    assertThat("Unexpected table.", metadata.getTableName(), is("CurriculumMembership"));
+    assertThat("Unexpected transaction id.", metadata.getTransactionId(), notNullValue());
+  }
+
+  @Test
+  void shouldAssembleProgrammeMembership() {
     PersonDTO personDto = new PersonDTO();
     personDto.setId(1L);
 
@@ -303,21 +372,12 @@ class DmsRecordAssemblerTest {
     curriculumMembershipDto.setCurriculumCompletionDate(LocalDate.of(2022, 1, 2));
     curriculumMembershipDto.setPeriodOfGrace(5);
     curriculumMembershipDto.setIntrepidId("12345");
-    curriculumMembershipDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
-
-    CurriculumMembershipDTO curriculumMembershipDto2 = new CurriculumMembershipDTO();
-    curriculumMembershipDto2.setCurriculumId(104L);
-    curriculumMembershipDto2.setId(101111L);
-    curriculumMembershipDto2.setCurriculumStartDate(LocalDate.of(3021, 2, 2));
-    curriculumMembershipDto2.setCurriculumEndDate(LocalDate.of(3022, 1, 1));
-    curriculumMembershipDto2.setCurriculumCompletionDate(LocalDate.of(3022, 1, 2));
-    curriculumMembershipDto2.setPeriodOfGrace(105);
-    curriculumMembershipDto2.setIntrepidId("1012345");
-    curriculumMembershipDto2.setAmendedDate(LocalDateTime.of(3021, 1, 1, 1, 1, 1));
+    curriculumMembershipDto.setAmendedDate(LocalDateTime.of(3021, 1, 1, 1, 1, 1));
 
     ProgrammeMembershipDTO programmeMembershipDto = new ProgrammeMembershipDTO();
     programmeMembershipDto.setId(1111L);
-    programmeMembershipDto.setUuid(UUID.fromString("123e4567-e89b-12d3-a456-426614174000"));
+    UUID programmeMembershipUuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    programmeMembershipDto.setUuid(programmeMembershipUuid);
     programmeMembershipDto.setPerson(personDto);
     programmeMembershipDto.setProgrammeId(123L);
     programmeMembershipDto.setRotation(rotationDto);
@@ -329,79 +389,40 @@ class DmsRecordAssemblerTest {
     programmeMembershipDto.setLeavingReason("a leaving reason");
     programmeMembershipDto.setLeavingDestination("a leaving destination");
     programmeMembershipDto.setCurriculumMemberships(
-        Arrays.asList(curriculumMembershipDto, curriculumMembershipDto2));
+        Collections.singletonList((curriculumMembershipDto)));
+    programmeMembershipDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
 
-    //when
     List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
         singletonList(programmeMembershipDto));
 
-    //then
-    assertThat("Unexpected DTO count.", dmsDtos.size(), is(2));
+    assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
+    assertThat("Unexpected data type.", dmsDto.getData(),
+        instanceOf(ProgrammeMembershipDmsDto.class));
+    ProgrammeMembershipDmsDto programmeMembershipDmsDto = (ProgrammeMembershipDmsDto) dmsDto.getData();
 
-    Object data = dmsDto.getData();
-    assertThat("Unexpected data.", data, instanceOf(CurriculumMembershipDmsDto.class));
-
-    CurriculumMembershipDmsDto CurriculumMembershipDmsDto = (CurriculumMembershipDmsDto) data;
-    assertThat("Unexpected id.",
-        CurriculumMembershipDmsDto.getId(),
-        is("1111"));
-    assertThat("Unexpected curriculum start date.",
-        CurriculumMembershipDmsDto.getCurriculumStartDate(),
-        is("2021-02-02"));
-    assertThat("Unexpected curriculum end date.",
-        CurriculumMembershipDmsDto.getCurriculumEndDate(),
-        is("2022-01-01"));
-    assertThat("Unexpected curriculum completion date.",
-        CurriculumMembershipDmsDto.getCurriculumCompletionDate(),
-        is("2022-01-02"));
-    assertThat("Unexpected period of grace.",
-        CurriculumMembershipDmsDto.getPeriodOfGrace(),
-        is("5"));
-    assertThat("Unexpected curriculum id.",
-        CurriculumMembershipDmsDto.getCurriculumId(),
-        is("4"));
-    assertThat("Unexpected intrepid id.",
-        CurriculumMembershipDmsDto.getIntrepidId(),
-        is("12345"));
-    assertThat("Unexpected amended date.",
-        CurriculumMembershipDmsDto.getAmendedDate(),
-        is(LocalDateTime.of(2021, 1, 1, 1, 1, 1).toString()));
-    assertThat("Unexpected programme membership UUID.",
-        CurriculumMembershipDmsDto.getProgrammeMembershipUuid(),
-        is("123e4567-e89b-12d3-a456-426614174000"));
-    assertThat("Unexpected person ID.",
-        CurriculumMembershipDmsDto.getPersonId(),
-        is("1"));
-    assertThat("Unexpected programme ID.",
-        CurriculumMembershipDmsDto.getProgrammeId(),
-        is("123"));
-    assertThat("Unexpected rotation ID.",
-        CurriculumMembershipDmsDto.getRotationId(),
-        is("2"));
-    assertThat("Unexpected rotation.",
-        CurriculumMembershipDmsDto.getRotation(),
-        is("a rotation"));
-    assertThat("Unexpected training number ID.",
-        CurriculumMembershipDmsDto.getTrainingNumberId(),
+    assertThat("Unexpected UUID.", programmeMembershipDmsDto.getUuid(),
+        is(programmeMembershipUuid));
+    assertThat("Unexpected person ID.", programmeMembershipDmsDto.getPersonId(), is("1"));
+    assertThat("Unexpected programme ID.", programmeMembershipDmsDto.getProgrammeId(), is("123"));
+    assertThat("Unexpected rotation ID.", programmeMembershipDmsDto.getRotationId(), is("2"));
+    assertThat("Unexpected rotation.", programmeMembershipDmsDto.getRotation(), is("a rotation"));
+    assertThat("Unexpected training number ID.", programmeMembershipDmsDto.getTrainingNumberId(),
         is("3"));
-    assertThat("Unexpected training pathway.",
-        CurriculumMembershipDmsDto.getTrainingPathway(),
-        is("a training pathway"));
     assertThat("Unexpected programme membership type.",
-        CurriculumMembershipDmsDto.getProgrammeMembershipType(),
+        programmeMembershipDmsDto.getProgrammeMembershipType(),
         is(ProgrammeMembershipType.SUBSTANTIVE.toString()));
     assertThat("Unexpected programme start date.",
-        CurriculumMembershipDmsDto.getProgrammeStartDate(),
-        is("2021-01-01"));
-    assertThat("Unexpected programme end date.",
-        CurriculumMembershipDmsDto.getProgrammeEndDate(),
+        programmeMembershipDmsDto.getProgrammeStartDate(), is("2021-01-01"));
+    assertThat("Unexpected programme end date.", programmeMembershipDmsDto.getProgrammeEndDate(),
         is("2022-02-02"));
-    assertThat("Unexpected leaving reason.",
-        CurriculumMembershipDmsDto.getLeavingReason(),
+    assertThat("Unexpected leaving reason.", programmeMembershipDmsDto.getLeavingReason(),
         is("a leaving reason"));
-    assertThat("Unexpected leaving destination.",
-        CurriculumMembershipDmsDto.getLeavingDestination(),
+    assertThat("Unexpected training pathway.", programmeMembershipDmsDto.getTrainingPathway(),
+        is("a training pathway"));
+    assertThat("Unexpected amended date.", programmeMembershipDmsDto.getAmendedDate(),
+        is(LocalDateTime.of(2021, 1, 1, 1, 1, 1).toString()));
+    assertThat("Unexpected leaving destination.", programmeMembershipDmsDto.getLeavingDestination(),
         is("a leaving destination"));
 
     MetadataDto metadata = dmsDto.getMetadata();
@@ -411,85 +432,8 @@ class DmsRecordAssemblerTest {
     assertThat("Unexpected partition key type.", metadata.getPartitionKeyType(),
         is("schema-table"));
     assertThat("Unexpected schema.", metadata.getSchemaName(), is("tcs"));
-    assertThat("Unexpected table.", metadata.getTableName(), is("CurriculumMembership"));
+    assertThat("Unexpected table.", metadata.getTableName(), is("ProgrammeMembership"));
     assertThat("Unexpected transaction id.", metadata.getTransactionId(), notNullValue());
-
-    DmsDto dmsDto2 = dmsDtos.get(1);
-
-    Object data2 = dmsDto2.getData();
-    assertThat("Unexpected data.", data2, instanceOf(CurriculumMembershipDmsDto.class));
-
-    CurriculumMembershipDmsDto CurriculumMembershipDmsDto2 = (CurriculumMembershipDmsDto) data2;
-    assertThat("Unexpected id.",
-        CurriculumMembershipDmsDto2.getId(),
-        is("101111"));
-    assertThat("Unexpected curriculum start date.",
-        CurriculumMembershipDmsDto2.getCurriculumStartDate(),
-        is("3021-02-02"));
-    assertThat("Unexpected curriculum end date.",
-        CurriculumMembershipDmsDto2.getCurriculumEndDate(),
-        is("3022-01-01"));
-    assertThat("Unexpected curriculum completion date.",
-        CurriculumMembershipDmsDto2.getCurriculumCompletionDate(),
-        is("3022-01-02"));
-    assertThat("Unexpected period of grace.",
-        CurriculumMembershipDmsDto2.getPeriodOfGrace(),
-        is("105"));
-    assertThat("Unexpected curriculum id.",
-        CurriculumMembershipDmsDto2.getCurriculumId(),
-        is("104"));
-    assertThat("Unexpected intrepid id.",
-        CurriculumMembershipDmsDto2.getIntrepidId(),
-        is("1012345"));
-    assertThat("Unexpected amended date.",
-        CurriculumMembershipDmsDto2.getAmendedDate(),
-        is(LocalDateTime.of(3021, 1, 1, 1, 1, 1).toString()));
-    assertThat("Unexpected programme membership UUID.",
-        CurriculumMembershipDmsDto2.getProgrammeMembershipUuid(),
-        is(CurriculumMembershipDmsDto.getProgrammeMembershipUuid()));
-    assertThat("Unexpected person ID.",
-        CurriculumMembershipDmsDto2.getPersonId(),
-        is(CurriculumMembershipDmsDto.getPersonId()));
-    assertThat("Unexpected programme ID.",
-        CurriculumMembershipDmsDto2.getProgrammeId(),
-        is(CurriculumMembershipDmsDto.getProgrammeId()));
-    assertThat("Unexpected rotation ID.",
-        CurriculumMembershipDmsDto2.getRotationId(),
-        is(CurriculumMembershipDmsDto.getRotationId()));
-    assertThat("Unexpected rotation.",
-        CurriculumMembershipDmsDto2.getRotation(),
-        is(CurriculumMembershipDmsDto.getRotation()));
-    assertThat("Unexpected training number ID.",
-        CurriculumMembershipDmsDto2.getTrainingNumberId(),
-        is(CurriculumMembershipDmsDto.getTrainingNumberId()));
-    assertThat("Unexpected training pathway.",
-        CurriculumMembershipDmsDto2.getTrainingPathway(),
-        is(CurriculumMembershipDmsDto.getTrainingPathway()));
-    assertThat("Unexpected programme membership type.",
-        CurriculumMembershipDmsDto2.getProgrammeMembershipType(),
-        is(CurriculumMembershipDmsDto.getProgrammeMembershipType()));
-    assertThat("Unexpected programme start date.",
-        CurriculumMembershipDmsDto2.getProgrammeStartDate(),
-        is(CurriculumMembershipDmsDto.getProgrammeStartDate()));
-    assertThat("Unexpected programme end date.",
-        CurriculumMembershipDmsDto2.getProgrammeEndDate(),
-        is(CurriculumMembershipDmsDto.getProgrammeEndDate()));
-    assertThat("Unexpected leaving reason.",
-        CurriculumMembershipDmsDto2.getLeavingReason(),
-        is(CurriculumMembershipDmsDto.getLeavingReason()));
-    assertThat("Unexpected leaving destination.",
-        CurriculumMembershipDmsDto2.getLeavingDestination(),
-        is(CurriculumMembershipDmsDto.getLeavingDestination()));
-
-    MetadataDto metadata2 = dmsDto2.getMetadata();
-    assertThat("Unexpected timestamp.", metadata2.getTimestamp(), notNullValue());
-    assertThat("Unexpected record type.", metadata2.getRecordType(), is("data"));
-    assertThat("Unexpected operation.", metadata2.getOperation(), is("load"));
-    assertThat("Unexpected partition key type.", metadata2.getPartitionKeyType(),
-        is("schema-table"));
-    assertThat("Unexpected schema.", metadata2.getSchemaName(), is("tcs"));
-    assertThat("Unexpected table.", metadata2.getTableName(), is("CurriculumMembership"));
-    assertThat("Unexpected transaction id.", metadata2.getTransactionId(), notNullValue());
   }
 
   @Test
@@ -508,7 +452,8 @@ class DmsRecordAssemblerTest {
     qualificationDto.setQualificationAttainedDate(LocalDate.MIN);
     qualificationDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
 
-    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(qualificationDto));
+    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(qualificationDto));
 
     assertThat("Unexpected DTO count.", actualDmsDtos.size(), is(1));
     DmsDto actualDmsDto = actualDmsDtos.get(0);


### PR DESCRIPTION
TSS needs the ability to request CurriculumMemberships and ProgrammeMemberships based on the associated Programme Membership UUID.

Currently the CurriculumMembershipDmsDto is made up of both CM and PM data, modify it to only contain CM data and move the PM data in to a new ProgrammeMembershipDmsDto.

Update the DataRequestService to handle requests for both CMs and PMs. A wrapper is needed for the CurriculumMembership so the PM UUID can be included, as the TCS CurriculumMembershipDTO does not include it.

TIS21-4173
TIS21-2399