### PR TITLE
fix: treat requested PM amended date as instant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.20.0</version>
+  <version>1.20.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/ProgrammeMembershipDmsDto.java
@@ -1,6 +1,8 @@
 package uk.nhs.tis.sync.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.Instant;
+import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Data;
 
@@ -18,10 +20,10 @@ public class ProgrammeMembershipDmsDto {
   private String rotation;
   private String trainingNumberId;
   private String programmeMembershipType;
-  private String programmeStartDate;
-  private String programmeEndDate;
+  private LocalDate programmeStartDate;
+  private LocalDate programmeEndDate;
   private String leavingReason;
   private String trainingPathway;
-  private String amendedDate;
+  private Instant amendedDate;
   private String leavingDestination;
 }

--- a/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/CurriculumMembershipMapper.java
@@ -19,7 +19,8 @@ public interface CurriculumMembershipMapper extends
   @Mapping(target = "id", source = "curriculumMembership.id")
   @Mapping(target = "curriculumStartDate", source = "curriculumMembership.curriculumStartDate")
   @Mapping(target = "curriculumEndDate", source = "curriculumMembership.curriculumEndDate")
-  @Mapping(target = "curriculumCompletionDate", source = "curriculumMembership.curriculumCompletionDate")
+  @Mapping(target = "curriculumCompletionDate",
+      source = "curriculumMembership.curriculumCompletionDate")
   @Mapping(target = "periodOfGrace", source = "curriculumMembership.periodOfGrace")
   @Mapping(target = "curriculumId", source = "curriculumMembership.curriculumId")
   @Mapping(target = "intrepidId", source = "curriculumMembership.intrepidId")

--- a/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/mapper/ProgrammeMembershipMapper.java
@@ -2,6 +2,9 @@ package uk.nhs.tis.sync.mapper;
 
 import com.transformuk.hee.tis.tcs.api.dto.ProgrammeMembershipDTO;
 import com.transformuk.hee.tis.tcs.api.enumeration.ProgrammeMembershipType;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import uk.nhs.tis.sync.dto.ProgrammeMembershipDmsDto;
@@ -39,5 +42,15 @@ public interface ProgrammeMembershipMapper extends
    */
   default String map(ProgrammeMembershipType source) {
     return source == null ? null : source.toString();
+  }
+
+  /**
+   * Maps a LocalDateTime to Instant, assumes UTC.
+   *
+   * @param source The local date time to map.
+   * @return The Instant value of the local date time.
+   */
+  default Instant map(LocalDateTime source) {
+    return source == null ? null : source.toInstant(ZoneOffset.UTC);
   }
 }

--- a/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
@@ -40,6 +40,7 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -384,13 +385,16 @@ class DmsRecordAssemblerTest {
     programmeMembershipDto.setTrainingNumber(trainingNumberDto);
     programmeMembershipDto.setTrainingPathway("a training pathway");
     programmeMembershipDto.setProgrammeMembershipType(ProgrammeMembershipType.SUBSTANTIVE);
-    programmeMembershipDto.setProgrammeStartDate(LocalDate.of(2021, 1, 1));
-    programmeMembershipDto.setProgrammeEndDate(LocalDate.of(2022, 2, 2));
+    LocalDate startDate = LocalDate.of(2021, 1, 1);
+    programmeMembershipDto.setProgrammeStartDate(startDate);
+    LocalDate endDate = LocalDate.of(2022, 2, 2);
+    programmeMembershipDto.setProgrammeEndDate(endDate);
     programmeMembershipDto.setLeavingReason("a leaving reason");
     programmeMembershipDto.setLeavingDestination("a leaving destination");
     programmeMembershipDto.setCurriculumMemberships(
         Collections.singletonList((curriculumMembershipDto)));
-    programmeMembershipDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
+    LocalDateTime amendedDate = LocalDateTime.of(2021, 1, 1, 1, 1, 1);
+    programmeMembershipDto.setAmendedDate(amendedDate);
 
     List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
         singletonList(programmeMembershipDto));
@@ -413,15 +417,15 @@ class DmsRecordAssemblerTest {
         programmeMembershipDmsDto.getProgrammeMembershipType(),
         is(ProgrammeMembershipType.SUBSTANTIVE.toString()));
     assertThat("Unexpected programme start date.",
-        programmeMembershipDmsDto.getProgrammeStartDate(), is("2021-01-01"));
+        programmeMembershipDmsDto.getProgrammeStartDate(), is(startDate));
     assertThat("Unexpected programme end date.", programmeMembershipDmsDto.getProgrammeEndDate(),
-        is("2022-02-02"));
+        is(endDate));
     assertThat("Unexpected leaving reason.", programmeMembershipDmsDto.getLeavingReason(),
         is("a leaving reason"));
     assertThat("Unexpected training pathway.", programmeMembershipDmsDto.getTrainingPathway(),
         is("a training pathway"));
     assertThat("Unexpected amended date.", programmeMembershipDmsDto.getAmendedDate(),
-        is(LocalDateTime.of(2021, 1, 1, 1, 1, 1).toString()));
+        is(amendedDate.toInstant(ZoneOffset.UTC)));
     assertThat("Unexpected leaving destination.", programmeMembershipDmsDto.getLeavingDestination(),
         is("a leaving destination"));
 


### PR DESCRIPTION
The trainee sync service expects the ProgrammeMembership amendedDate field to be a timestamp, similar to the raw database data received via DMS.

When fulfilling a request for a PM, the LocalDateTime is used from the TCS DTO and is directly converted to a string.
This results in a string format with no zone information, causing failures in trainee sync.

Update the ProgrammeMembershipMapper to handle LocalDateTime to Instant conversion (assuming UTC, since there is no other information available).
Update ProgrammeMembershipDmsDto to use appropriate date types for `programmeStartDate`, `programmeEndDate` and `amendedDate`.

TIS21-4173
TIS21-2399