### PR TITLE
fix:set null values when last ResultSet col was null

### DIFF
--- a/src/main/java/uk/nhs/tis/sync/service/impl/PersonViewRowMapper.java
+++ b/src/main/java/uk/nhs/tis/sync/service/impl/PersonViewRowMapper.java
@@ -21,10 +21,16 @@ public class PersonViewRowMapper implements RowMapper<PersonView> {
     view.setGdcNumber(rs.getString("gdcNumber"));
     view.setPublicHealthNumber(rs.getString("publicHealthNumber"));
     view.setGradeId(rs.getLong("gradeId"));
+    if (rs.wasNull()) {
+      view.setGradeId(null);
+    }
     view.setGradeAbbreviation(rs.getString("gradeAbbreviation"));
 
     view.setSiteCode(rs.getString("siteCode"));
     view.setSiteId(rs.getLong("siteId"));
+    if (rs.wasNull()) {
+      view.setSiteId(null);
+    }
     view.setPlacementType(rs.getString("placementType"));
     view.setSpecialty(rs.getString("specialty"));
     view.setRole(rs.getString("role"));


### PR DESCRIPTION
Before (now on Prod):
![image](https://github.com/Health-Education-England/TIS-SYNC/assets/33690649/23d8ed55-4c25-4739-af83-eb7d0da40f4b)

We can notice there're a lot of `0` in gradeId or siteId, because ResultSet.getLong() returns a 0 when the value is NULL, see documentation here: https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSet.html
But we in the Decorator, we treat the data as NULL rather than 0: 
https://github.com/Health-Education-England/TIS-SYNC/blob/b76cfe545b0520ae89b917ddddd34e3da44a37c4/src/main/java/uk/nhs/tis/sync/service/api/decorator/PersonViewDecorator.java#L39

After (tested locally):
![image](https://github.com/Health-Education-England/TIS-SYNC/assets/33690649/408e64d6-f303-4bea-b3fb-1d8dd3f791e9)

This will also benefit the `PersonViewDecorator` in TCS, as PersonViewDecorator decorates person views from ES with sites and grades from reference service.

TIS21-4739