### PR TITLE
fix: use correct partition key for kinesis data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.21.0</version>
+  <version>1.21.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -235,7 +235,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.16</version>
+              <version>1.18.22</version>
             </path>
             <path>
               <groupId>org.mapstruct</groupId>

--- a/src/main/java/uk/nhs/tis/sync/service/KinesisService.java
+++ b/src/main/java/uk/nhs/tis/sync/service/KinesisService.java
@@ -25,7 +25,6 @@ import uk.nhs.tis.sync.dto.DmsDto;
 @Service
 public class KinesisService {
 
-  public static final String PARTITION_KEY = "0";
   private final AmazonKinesis amazonKinesis;
   private final ObjectMapper objectMapper;
 
@@ -70,7 +69,9 @@ public class KinesisService {
         PutRecordsRequestEntry putRecordsRequestEntry = new PutRecordsRequestEntry();
         putRecordsRequestEntry.setData(ByteBuffer.wrap(jsonString.getBytes()));
         putRecordsRequestEntryList.add(putRecordsRequestEntry);
-        putRecordsRequestEntry.setPartitionKey(PARTITION_KEY);
+        String partitionKey = String.format("%s.%s",
+            dmsDto.getMetadata().getSchemaName(), dmsDto.getMetadata().getTableName());
+        putRecordsRequestEntry.setPartitionKey(partitionKey);
       }
 
       putRecordsRequest.setRecords(putRecordsRequestEntryList);

--- a/src/test/java/uk/nhs/tis/sync/service/KinesisServiceTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/KinesisServiceTest.java
@@ -114,10 +114,12 @@ class KinesisServiceTest {
     PutRecordsRequestEntry putRecordsRequestEntry1 = putRecordsRequestEntryList.get(0);
     byte[] entry1 = putRecordsRequestEntry1.getData().array();
     String actualRecord1 = new String(entry1, StandardCharsets.ISO_8859_1);
+    String actualRecord1PartitionKey = putRecordsRequestEntry1.getPartitionKey();
 
     PutRecordsRequestEntry putRecordsRequestEntry2 = putRecordsRequestEntryList.get(1);
     byte[] entry2 = putRecordsRequestEntry2.getData().array();
     String actualRecord2 = new String(entry2, StandardCharsets.ISO_8859_1);
+    String actualRecord2PartitionKey = putRecordsRequestEntry2.getPartitionKey();
 
     String expectedRecord1 = "{\n" +
         "\"data\":\t{\n" +
@@ -173,6 +175,11 @@ class KinesisServiceTest {
 
     JSONAssert.assertEquals(expectedJsonRecord1, actualJsonRecord1, false);
     JSONAssert.assertEquals(expectedJsonRecord2, actualJsonRecord2, false);
+
+    assertThat("Unexpected record 1 partition key.", actualRecord1PartitionKey,
+        is("tcs.Post"));
+    assertThat("Unexpected record 2 partition key.", actualRecord2PartitionKey,
+        is("reference.Trust"));
   }
 
   @Test


### PR DESCRIPTION
At the moment, tis-sync sends everything with partition key '0', e.g. PlacementSpecialty records coming in on shard 1 with partition key '0'. This should be adjusted to match the default schema.table partition keys (which put PlacementSpecialties onto shard 0, as a matter of fact).

![image](https://github.com/Health-Education-England/TIS-SYNC/assets/74923923/a6a2020d-9367-47ee-95ff-3dbc4ffffc6e)

TIS21-6028
TIS21-6030