### PR TITLE
Fix: use new tss fifo queue

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -111,7 +111,7 @@
         },
         {
           "name": "AWS_SQS_QUEUE_URL",
-          "valueFrom": "sqs-queue-url-sync-${environment}-fifo"
+          "valueFrom": "/tis/trainee/sync/${environment}/queue-url-fifo"
         },
         {
           "name": "RABBITMQ_HOST",

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -111,7 +111,7 @@
         },
         {
           "name": "AWS_SQS_QUEUE_URL",
-          "valueFrom": "sqs-queue-url-sync-${environment}"
+          "valueFrom": "sqs-queue-url-sync-${environment}-fifo"
         },
         {
           "name": "RABBITMQ_HOST",

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.21.1</version>
+  <version>1.21.2</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>


### PR DESCRIPTION
Switched to using the parameter store entry that TSS uses as well.

Roll-out plan for this is itemised here: https://hee-tis.atlassian.net/browse/TIS21-6028?focusedCommentId=88927

TIS21-6136