### PR TITLE
chore: bump TCS Persistence 2.32.0 -> 2.32.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
     <dependency>
       <groupId>uk.nhs.tis</groupId>
       <artifactId>tcs-persistence</artifactId>
-      <version>2.32.0</version>
+      <version>2.32.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee.tis</groupId>
       <artifactId>tcs-client</artifactId>
-      <version>6.2.2</version>
+      <version>6.2.4</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>


### PR DESCRIPTION
The PersonOwner job failed due to missing enum values. A GoldGuideVersion 10 was added but not everywhere.

chore: bump TCS Client

This also uses the API and is done for consistently choosing the latest available patches.

NO-CARD: Just Fixing It