### PR TITLE
Feat/include tis metadata in data request msgs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.24.1</version>
+  <version>1.25.0</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/dto/MetadataDto.java
+++ b/src/main/java/uk/nhs/tis/sync/dto/MetadataDto.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({"timestamp", "record-type", "operation", "partition-key-type", "schema-name",
-    "table-name", "transaction-id"})
+    "table-name", "transaction-id", "tis-trigger", "tis-trigger-detail"})
 public class MetadataDto {
   @JsonProperty("timestamp") String timestamp;
   @JsonProperty("record-type") String recordType;
@@ -21,4 +21,6 @@ public class MetadataDto {
   @JsonProperty("schema-name") String schemaName;
   @JsonProperty("table-name") String tableName;
   @JsonProperty("transaction-id") String transactionId;
+  @JsonProperty("tis-trigger") String tisTrigger;
+  @JsonProperty("tis-trigger-detail") String tisTriggerDetail;
 }

--- a/src/main/java/uk/nhs/tis/sync/job/RecordResendingJob.java
+++ b/src/main/java/uk/nhs/tis/sync/job/RecordResendingJob.java
@@ -120,7 +120,8 @@ public class RecordResendingJob {
       List<Object> retrievedDtos = dataRequestService.retrieveDtos(messageMap);
 
       if (!retrievedDtos.isEmpty()) {
-        return dmsRecordAssembler.assembleDmsDtos(retrievedDtos);
+        return dmsRecordAssembler.assembleDmsDtos(retrievedDtos,
+            messageMap.get("tisTrigger"), messageMap.get("tisTriggerDetail"));
       }
     } catch (JsonProcessingException e) {
       LOG.error(e.getMessage(), e);

--- a/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
+++ b/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
@@ -28,6 +28,7 @@ public class DataRequestService {
   private static final String TABLE_CURRICULUM = "Curriculum";
   private static final String TABLE_CURRICULUM_MEMBERSHIP = "CurriculumMembership";
   private static final String TABLE_DBC = "DBC";
+  private static final String TABLE_GMC = "GmcDetails";
   private static final String TABLE_GRADE = "Grade";
   private static final String TABLE_HEE_USER = "HeeUser";
   private static final String TABLE_LOCAL_OFFICE = "LocalOffice";
@@ -105,6 +106,9 @@ public class DataRequestService {
       case TABLE_GRADE:
         return createNonNullList(
             referenceServiceImpl.findGradesIdIn(Collections.singleton(id)).get(0));
+      case TABLE_GMC:
+        return createNonNullList(tcsServiceImpl.findGmcDetailsIn(
+            Collections.singletonList(String.valueOf(id))));
       default:
         return Collections.emptyList();
     }
@@ -166,7 +170,7 @@ public class DataRequestService {
       return createNonNullList(
           referenceServiceImpl.findLocalOfficesByName(name).get(0));
     }
-    
+
     return Collections.emptyList();
   }
 

--- a/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
+++ b/src/main/java/uk/nhs/tis/sync/service/DataRequestService.java
@@ -108,7 +108,7 @@ public class DataRequestService {
             referenceServiceImpl.findGradesIdIn(Collections.singleton(id)).get(0));
       case TABLE_GMC:
         return createNonNullList(tcsServiceImpl.findGmcDetailsIn(
-            Collections.singletonList(String.valueOf(id))));
+            Collections.singletonList(String.valueOf(id))).get(0));
       default:
         return Collections.emptyList();
     }
@@ -170,7 +170,6 @@ public class DataRequestService {
       return createNonNullList(
           referenceServiceImpl.findLocalOfficesByName(name).get(0));
     }
-
     return Collections.emptyList();
   }
 

--- a/src/main/java/uk/nhs/tis/sync/service/DmsRecordAssembler.java
+++ b/src/main/java/uk/nhs/tis/sync/service/DmsRecordAssembler.java
@@ -28,9 +28,10 @@ public class DmsRecordAssembler {
    * @param dtos The dto objects which will be mapped to DmsDtos.
    * @return The assembled DmsDtos
    */
-  public List<DmsDto> assembleDmsDtos(List<Object> dtos) {
+  public List<DmsDto> assembleDmsDtos(List<Object> dtos, String tisTrigger,
+      String tisTriggerDetail) {
     return dtos.stream()
-        .map(this::assembleDmsDto)
+        .map(dto -> assembleDmsDto(dto, tisTrigger, tisTriggerDetail))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
@@ -42,7 +43,7 @@ public class DmsRecordAssembler {
    *            a DmsDto (e.g. PostDmsDto).
    * @return The list of DmsDtos, complete with data and metadata.
    */
-  private List<DmsDto> assembleDmsDto(Object dto) {
+  private List<DmsDto> assembleDmsDto(Object dto, String tisTrigger, String tisTriggerDetail) {
     List<DmsDto> dmsDtoList = new ArrayList<>();
     List<Object> dmsDataList = new ArrayList<>();
     String schema = null;
@@ -66,7 +67,8 @@ public class DmsRecordAssembler {
     if (!dmsDataList.isEmpty()) {
       for (Object dmsData : dmsDataList) {
         MetadataDto metadata = new MetadataDto(Instant.now().toString(), DATA, LOAD,
-            PARTITION_KEY_TYPE, schema, table, UUID.randomUUID().toString());
+            PARTITION_KEY_TYPE, schema, table, UUID.randomUUID().toString(),
+            tisTrigger, tisTriggerDetail);
         dmsDtoList.add(new DmsDto(dmsData, metadata));
       }
     }

--- a/src/test/java/uk/nhs/tis/sync/service/DataRequestServiceTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/DataRequestServiceTest.java
@@ -990,4 +990,48 @@ class DataRequestServiceTest {
     assertThat("Unexpected DTO count.", dbcs.size(), is(0));
     verifyNoInteractions(referenceService);
   }
+
+  @Test
+  void shouldReturnGmcDetailsWhenGmcDetailsFound() {
+    GmcDetailsDTO expectedDto = new GmcDetailsDTO();
+    when(tcsService.findGmcDetailsIn(Collections.singletonList("40")))
+        .thenReturn(Collections.singletonList(expectedDto));
+
+    Map<String, String> message = new HashMap<String, String>() {{
+      put("table", "GmcDetails");
+      put("id", "40");
+    }};
+    List<Object> retrievedDtos = service.retrieveDtos(message);
+
+    assertThat("Unexpected DTO count.", retrievedDtos.size(), is(1));
+    assertThat("Unexpected DTO.", retrievedDtos.get(0), sameInstance(expectedDto));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenGmcDetailsNotFound() {
+    when(tcsService.findGmcDetailsIn(Collections.singletonList("40")))
+        .thenReturn(null);
+
+    Map<String, String> message = new HashMap<String, String>() {{
+      put("table", "GmcDetails");
+      put("id", "40");
+    }};
+    List<Object> gmcDetailsList = service.retrieveDtos(message);
+
+    assertThat("Unexpected DTO count.", gmcDetailsList.size(), is(0));
+  }
+
+  @Test
+  void shouldReturnEmptyWhenGetGmcDetailsByIdThrowsException() {
+    when(tcsService.findGmcDetailsIn(Collections.singletonList("40")))
+        .thenThrow(new RuntimeException("Expected exception."));
+
+    Map<String, String> message = new HashMap<String, String>() {{
+      put("table", "GmcDetails");
+      put("id", "40");
+    }};
+    List<Object> gmcDetailsList = service.retrieveDtos(message);
+
+    assertThat("Unexpected DTO count.", gmcDetailsList.size(), is(0));
+  }
 }

--- a/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
+++ b/src/test/java/uk/nhs/tis/sync/service/DmsRecordAssemblerTest.java
@@ -68,6 +68,8 @@ import uk.nhs.tis.sync.dto.SpecialtyDmsDto;
 import uk.nhs.tis.sync.dto.TrustDmsDto;
 
 class DmsRecordAssemblerTest {
+  private static final String TIS_TRIGGER = "trigger";
+  private static final String TIS_TRIGGER_DETAIL = "details";
 
   private DmsRecordAssembler dmsRecordAssembler;
 
@@ -85,7 +87,7 @@ class DmsRecordAssemblerTest {
     programme.setId(2L);
 
     List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
-        Arrays.asList(post, new Object(), programme));
+        Arrays.asList(post, new Object(), programme), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DMS DTO count.", dmsDtos.size(), is(2));
 
@@ -105,7 +107,8 @@ class DmsRecordAssemblerTest {
     ContactDetailsDTO contactDetails = new ContactDetailsDTO();
     contactDetails.setId(10L);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(contactDetails));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(contactDetails), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -127,7 +130,8 @@ class DmsRecordAssemblerTest {
     GdcDetailsDTO gdcDetails = new GdcDetailsDTO();
     gdcDetails.setId(10L);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(gdcDetails));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(gdcDetails), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -149,7 +153,8 @@ class DmsRecordAssemblerTest {
     GmcDetailsDTO gmcDetails = new GmcDetailsDTO();
     gmcDetails.setId(10L);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(gmcDetails));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(gmcDetails), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -181,7 +186,8 @@ class DmsRecordAssemblerTest {
     person.setPublicHealthNumber("ph123");
     person.setRegulator("regulator");
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(person));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(person), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -218,7 +224,8 @@ class DmsRecordAssemblerTest {
     PersonalDetailsDTO personalDetails = new PersonalDetailsDTO();
     personalDetails.setId(10L);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(personalDetails));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(personalDetails), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -251,7 +258,8 @@ class DmsRecordAssemblerTest {
     postDto.owner("Health Education England North West London");
     postDto.intrepidId("128374444");
 
-    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(postDto));
+    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(postDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", actualDmsDtos.size(), is(1));
     DmsDto actualDmsDto = actualDmsDtos.get(0);
@@ -281,6 +289,8 @@ class DmsRecordAssemblerTest {
     expectedMetadataDto.setSchemaName("tcs");
     expectedMetadataDto.setTableName("Post");
     expectedMetadataDto.setTransactionId(transactionId);
+    expectedMetadataDto.setTisTrigger(TIS_TRIGGER);
+    expectedMetadataDto.setTisTriggerDetail(TIS_TRIGGER_DETAIL);
 
     DmsDto expectedDmsDto = new DmsDto(expectedPostDmsDto, expectedMetadataDto);
 
@@ -303,8 +313,8 @@ class DmsRecordAssemblerTest {
         UUID.fromString("123e4567-e89b-12d3-a456-426614174000"), curriculumMembershipDto);
 
     //when
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(
-        curriculumMembershipWrapperDto));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(curriculumMembershipWrapperDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     //then
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
@@ -397,7 +407,7 @@ class DmsRecordAssemblerTest {
     programmeMembershipDto.setAmendedDate(amendedDate);
 
     List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
-        singletonList(programmeMembershipDto));
+        singletonList(programmeMembershipDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -457,7 +467,7 @@ class DmsRecordAssemblerTest {
     qualificationDto.setAmendedDate(LocalDateTime.of(2021, 1, 1, 1, 1, 1));
 
     List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(
-        singletonList(qualificationDto));
+        singletonList(qualificationDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", actualDmsDtos.size(), is(1));
     DmsDto actualDmsDto = actualDmsDtos.get(0);
@@ -508,7 +518,8 @@ class DmsRecordAssemblerTest {
     trustDto.setIntrepidId("222");
     trustDto.setId(333L);
 
-    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(trustDto));
+    List<DmsDto> actualDmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(trustDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", actualDmsDtos.size(), is(1));
     DmsDto actualDmsDto = actualDmsDtos.get(0);
@@ -537,6 +548,8 @@ class DmsRecordAssemblerTest {
     expectedMetadataDto.setSchemaName("reference");
     expectedMetadataDto.setTableName("Trust");
     expectedMetadataDto.setTransactionId(transactionId);
+    expectedMetadataDto.setTisTrigger(TIS_TRIGGER);
+    expectedMetadataDto.setTisTriggerDetail(TIS_TRIGGER_DETAIL);
 
     DmsDto expectedDmsDto = new DmsDto(expectedTrustDmsDto, expectedMetadataDto);
 
@@ -562,7 +575,8 @@ class DmsRecordAssemblerTest {
     site.setPostCode("AB12 3CD");
     site.setStatus(CURRENT);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(site));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(site), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -599,7 +613,8 @@ class DmsRecordAssemblerTest {
 
   @Test
   void shouldReturnEmptyWhenUnsupportedType() {
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(new Object()));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(new Object()), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
     assertThat("Unexpected dms dto count.", dmsDtos.size(), is(0));
   }
 
@@ -613,7 +628,8 @@ class DmsRecordAssemblerTest {
     programme.setProgrammeNumber("500");
     programme.setStatus(Status.CURRENT);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(programme));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(programme), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -658,7 +674,8 @@ class DmsRecordAssemblerTest {
     curriculum.setStatus(Status.CURRENT);
     curriculum.setLength(12);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(curriculum));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(curriculum), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -706,7 +723,8 @@ class DmsRecordAssemblerTest {
     specialtyGroupDto.setId(75L);
     specialty.setSpecialtyGroup(specialtyGroupDto);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(specialty));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(specialty), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -742,7 +760,8 @@ class DmsRecordAssemblerTest {
     placementSpecialty.setPlacementSpecialtyType(PostSpecialtyType.PRIMARY);
     placementSpecialty.setSpecialtyName("specialtyName");
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(placementSpecialty));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(placementSpecialty), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -783,7 +802,8 @@ class DmsRecordAssemblerTest {
     placementSummaryDto.setGradeId(20L);
     placementSummaryDto.setSiteId(30L);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(placementSummaryDto));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(placementSummaryDto), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);
@@ -832,7 +852,8 @@ class DmsRecordAssemblerTest {
     grade.setPostGrade(false);
     grade.setTrainingGrade(true);
 
-    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(singletonList(grade));
+    List<DmsDto> dmsDtos = dmsRecordAssembler.assembleDmsDtos(
+        singletonList(grade), TIS_TRIGGER, TIS_TRIGGER_DETAIL);
 
     assertThat("Unexpected DTO count.", dmsDtos.size(), is(1));
     DmsDto dmsDto = dmsDtos.get(0);


### PR DESCRIPTION
To pass on to kinesis and hence tis-trainee-sync to allow handling of failed trainee data updates. Related PR: https://github.com/Health-Education-England/TIS-TCS/pull/1035

TIS21-6639