### PR TITLE
fix: set msg attribs for sending to FIFO SQS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
   <groupId>uk.nhs.tis</groupId>
   <artifactId>sync</artifactId>
-  <version>1.25.0</version>
+  <version>1.25.1</version>
   <packaging>jar</packaging>
   <name>sync</name>
   <description>Separate Microservice for synchronisation</description>

--- a/src/main/java/uk/nhs/tis/sync/message/listener/RabbitMqTssRejectedGmcUpdateListener.java
+++ b/src/main/java/uk/nhs/tis/sync/message/listener/RabbitMqTssRejectedGmcUpdateListener.java
@@ -60,7 +60,11 @@ public class RabbitMqTssRejectedGmcUpdateListener {
       messageMap.put("tisTrigger", TIS_TRIGGER_MESSAGE);
       messageMap.put("tisTriggerDetail", "Received " + LocalDateTime.now());
       String messageBody = objectMapper.writeValueAsString(messageMap);
-      sqs.sendMessage(queueUrl, messageBody);
+      SendMessageRequest msgRequest = new SendMessageRequest(queueUrl, messageBody);
+      String messageGroupAndDedup = TABLE_GMC + "_" + event.getPersonId().toString();
+      msgRequest.setMessageGroupId(messageGroupAndDedup);
+      msgRequest.setMessageDeduplicationId(messageGroupAndDedup);
+      sqs.sendMessage(msgRequest);
       log.info("Rejected GMC update received and data request made to reset value in TSS: {}",
           messageBody);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
Omitted due to forgetting that local env queues differ from 'real' queues in this respect 🤦 

TIS21-6639